### PR TITLE
optional addresses for Wizaplace\User

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -29,8 +29,8 @@ class User
         $this->email = (string) $data['email'];
         $this->firstname = (string) $data['firstName'];
         $this->lastname = (string) $data['lastName'];
-        $this->billingAddress = $data['addresses']['billing'] ?? null;
-        $this->shippingAddress = $data['addresses']['shipping'] ?? null;
+        $this->billingAddress = $data['addresses']['billing'] ?? [];
+        $this->shippingAddress = $data['addresses']['shipping'] ?? [];
     }
 
     public function getId(): int


### PR DESCRIPTION
Lors de la création d'un Wizaplace\User, on a pas forcément l'information concernant ses adresses
Ex. : L'utilisateur veut mettre à jour son profil, mais n'a pas déjà rempli toutes ses informations d'adresses.