### PR TITLE
Message's isAuthor()

### DIFF
--- a/src/Discussion/DiscussionService.php
+++ b/src/Discussion/DiscussionService.php
@@ -10,6 +10,7 @@ namespace Wizaplace\Discussion;
 
 use GuzzleHttp\Exception\ClientException;
 use Wizaplace\AbstractService;
+use Wizaplace\Authentication\AuthenticationRequired;
 use Wizaplace\Exception\NotFound;
 use Wizaplace\Exception\SomeParametersAreInvalid;
 
@@ -39,10 +40,14 @@ final class DiscussionService extends AbstractService
 {
     /**
      * Get the user's discussions list
+     *
      * @return Discussion[]
+     * @throws AuthenticationRequired
      */
     public function getDiscussions(): array
     {
+        $this->client->mustBeAuthenticated();
+
         $discussions = array_map(function (array $discussionData): Discussion {
             return new Discussion($discussionData);
         }, $this->client->get('discussions'));
@@ -50,9 +55,16 @@ final class DiscussionService extends AbstractService
         return $discussions;
     }
 
-    /** Get a discussion based on its id */
+    /**
+     * Get a discussion based on its id
+     *
+     * @throws NotFound
+     * @throws AuthenticationRequired
+     */
     public function getDiscussion(int $discussionId): Discussion
     {
+        $this->client->mustBeAuthenticated();
+
         try {
             return new Discussion($this->client->get('discussions/'.$discussionId));
         } catch (ClientException $e) {
@@ -60,9 +72,16 @@ final class DiscussionService extends AbstractService
         }
     }
 
-    /** Start a discussion with a vendor about a specific product. */
+    /**
+     * Start a discussion with a vendor about a specific product.
+     *
+     * @throws NotFound
+     * @throws AuthenticationRequired
+     */
     public function startDiscussion(int $productId): Discussion
     {
+        $this->client->mustBeAuthenticated();
+
         try {
             $discussionData = $this->client->post('discussions', ['json' => ['productId' => $productId]]);
 
@@ -75,11 +94,15 @@ final class DiscussionService extends AbstractService
     /**
      * Get the discussion's messages list
      * @return Message[]
+     * @throws AuthenticationRequired
      */
-    public function getMessages(int $discussionId, int $userId): array
+    public function getMessages(int $discussionId): array
     {
+        $this->client->mustBeAuthenticated();
+
         try {
             $messages = $this->client->get('discussions/'.$discussionId.'/messages');
+            $userId = $this->client->getApiKey()->getId();
 
             return array_map(function (array $messageData) use ($userId): Message {
                 $messageData['isAuthor'] = ($messageData['author'] === $userId);
@@ -91,11 +114,19 @@ final class DiscussionService extends AbstractService
         }
     }
 
-    /** Post a new message in the discussion */
+    /**
+     * Post a new message in the discussion
+     *
+     * @throws SomeParametersAreInvalid
+     * @throws AuthenticationRequired
+     */
     public function postMessage(int $discussionId, string $content): Message
     {
+        $this->client->mustBeAuthenticated();
+
         try {
             $messageData = $this->client->post('discussions/'.$discussionId.'/messages', ['json' => ['content' => $content]]);
+            $messageData['isAuthor'] = ($messageData['author'] === $this->client->getApiKey()->getId());
 
             return new Message($messageData);
         } catch (ClientException $e) {

--- a/src/Discussion/Message.php
+++ b/src/Discussion/Message.php
@@ -41,6 +41,6 @@ final class Message
 
     public function isAuthor(): bool
     {
-        return $this->isAuthor();
+        return $this->isAuthor;
     }
 }

--- a/tests/Discussion/DiscussionServiceTest.php
+++ b/tests/Discussion/DiscussionServiceTest.php
@@ -100,7 +100,7 @@ final class DiscussionServiceTest extends ApiTestCase
 
     public function testGetEmptyMessages()
     {
-        $messages = $this->discussionService->getMessages(1, 1);
+        $messages = $this->discussionService->getMessages(1);
 
         $this->assertSame([], $messages);
     }
@@ -111,7 +111,7 @@ final class DiscussionServiceTest extends ApiTestCase
         $this->expectExceptionCode(404);
         $this->expectExceptionMessage('The discussion 2 was not found.');
 
-        $this->discussionService->getMessages(2, 1);
+        $this->discussionService->getMessages(2);
     }
 
     public function testPostMessage()
@@ -122,7 +122,7 @@ final class DiscussionServiceTest extends ApiTestCase
 
         $expectedMessage = new Message(
             [
-                'author' => 3,
+                'isAuthor' => true,
                 'content' => 'This is a test message',
                 'date' => $date->format(DATE_RFC3339),
             ]
@@ -136,18 +136,18 @@ final class DiscussionServiceTest extends ApiTestCase
     {
         $this->discussionService->postMessage(1, 'This is an other test message');
 
-        $messages = $this->discussionService->getMessages(1, 3);
+        $messages = $this->discussionService->getMessages(1);
 
         $date = new \DateTimeImmutable();
 
         $expectedMessages = [
             new Message([
-                'author' => 3,
+                'isAuthor' => true,
                 'content' => 'This is a test message',
                 'date' => $date->format(DATE_RFC3339),
             ]),
             new Message([
-                'author' => 3,
+                'isAuthor' => true,
                 'content' => 'This is an other test message',
                 'date' => $date->format(DATE_RFC3339),
             ]),
@@ -157,7 +157,7 @@ final class DiscussionServiceTest extends ApiTestCase
         $this->assertInstanceOf(\DateTimeImmutable::class, $messages[0]->getDate());
         $this->assertSame($expectedMessages[1]->getContent(), $messages[1]->getContent());
         $this->assertInstanceOf(\DateTimeImmutable::class, $messages[1]->getDate());
-        $this->assertSame(true, $messages[0]->isAuthor());
+        $this->assertSame($expectedMessages[0]->isAuthor(), $messages[0]->isAuthor());
     }
 
     private function buildDiscussionService(): DiscussionService


### PR DESCRIPTION
# Ajout d'une méthode `isAuthor()`

_**Ne pas hésiter à squash au moment du merge**_

### Besoin:
On veut pouvoir savoir si le `currentUser` est l'auteur d'un `Message`.

### Méthode:

- [x] Ajout de la propriété `isAuthor` et de la méthode `isAuthor()` (pas sûr du naming ?)
- [x] Attribution du résultat de `authorId === userId` à `isAuthor`