### PR TITLE
Mark `getUrl` methods as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### New features
 
 - Added `\Wizaplace\Discussion\Message::isAuthor`
+- Mark `\Wizaplace\Company\CompanyRegistration::getUrl` as deprecated
+- Mark `\Wizaplace\Catalog\Product::getUrl` as deprecated
+- Mark `\Wizaplace\Catalog\ProductSummary::getUrl` as deprecated
 
 ### Bugfixes
 

--- a/src/Catalog/Product.php
+++ b/src/Catalog/Product.php
@@ -132,6 +132,9 @@ final class Product
         return $this->name;
     }
 
+    /**
+     * @deprecated
+     */
     public function getUrl(): string
     {
         return $this->url;

--- a/src/Catalog/ProductSummary.php
+++ b/src/Catalog/ProductSummary.php
@@ -114,6 +114,9 @@ final class ProductSummary
         return $this->isAvailable;
     }
 
+    /**
+     * @deprecated
+     */
     public function getUrl(): string
     {
         return $this->url;

--- a/src/Company/Company.php
+++ b/src/Company/Company.php
@@ -134,6 +134,9 @@ final class Company
         return $this->fax;
     }
 
+    /**
+     * @deprecated
+     */
     public function getUrl(): string
     {
         return $this->url;

--- a/src/Company/CompanyRegistration.php
+++ b/src/Company/CompanyRegistration.php
@@ -163,6 +163,9 @@ final class CompanyRegistration
         $this->fax = $fax;
     }
 
+    /**
+     * @deprecated
+     */
     public function getUrl(): ?string
     {
         return $this->url;


### PR DESCRIPTION
Ces URLs ne sont jamais correctes pour les nouveaux fronts. Elles vont disparaître petit à petit.

## Checklist

- [x] Changelog updated
