### PR TITLE
changed parameters type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `\Wizaplace\Favorite\FavoriteService::isInFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
 - `\Wizaplace\Favorite\FavoriteService::addDeclinationToUserFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
+- `\Wizaplace\Favorite\FavoriteService::removeDeclinationToUserFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### BREAKING CHANGES
 
+- `\Wizaplace\Favorite\FavoriteService::isInFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
+- `\Wizaplace\Favorite\FavoriteService::addDeclinationToUserFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
+
 ### New features
 
 - Added `\Wizaplace\Basket\BasketItem::getDeclinationOptions`

--- a/src/Favorite/Exception/CannotFavoriteDisabledOrInexistentDeclination.php
+++ b/src/Favorite/Exception/CannotFavoriteDisabledOrInexistentDeclination.php
@@ -13,10 +13,10 @@ final class CannotFavoriteDisabledOrInexistentDeclination extends \Exception
     /**
      * @internal
      */
-    public function __construct(int $productId, \Throwable $previous = null)
+    public function __construct(string $declinationId, \Throwable $previous = null)
     {
         parent::__construct(
-            "Product #{$productId} cannot be added to favorite as it is disabled or does not exist",
+            "Declination #{$declinationId} cannot be added to favorite as it is disabled or does not exist",
             self::HTTP_ERROR_CODE,
             $previous
         );

--- a/src/Favorite/Exception/FavoriteAlreadyExist.php
+++ b/src/Favorite/Exception/FavoriteAlreadyExist.php
@@ -13,8 +13,8 @@ final class FavoriteAlreadyExist extends \Exception
     /**
      * @internal
      */
-    public function __construct(int $productId, \Throwable $previous = null)
+    public function __construct(string $declinationId, \Throwable $previous = null)
     {
-        parent::__construct("Product #{$productId} is already a favorite", self::HTTP_ERROR_CODE, $previous);
+        parent::__construct("Declination #{$declinationId} is already a favorite", self::HTTP_ERROR_CODE, $previous);
     }
 }

--- a/src/Favorite/FavoriteService.php
+++ b/src/Favorite/FavoriteService.php
@@ -40,7 +40,7 @@ final class FavoriteService extends AbstractService
      *
      * @throws AuthenticationRequired
      */
-    public function isInFavorites(int $declinationId) : bool
+    public function isInFavorites(string $declinationId) : bool
     {
         $this->client->mustBeAuthenticated();
         $results = $this->client->get('user/favorites/declinations/ids', []);
@@ -63,7 +63,7 @@ final class FavoriteService extends AbstractService
      * @throws CannotFavoriteDisabledOrInexistentDeclination
      * @throws FavoriteAlreadyExist
      */
-    public function addDeclinationToUserFavorites(int $declinationId) : void
+    public function addDeclinationToUserFavorites(string $declinationId) : void
     {
         $this->client->mustBeAuthenticated();
         try {

--- a/src/Favorite/FavoriteService.php
+++ b/src/Favorite/FavoriteService.php
@@ -86,7 +86,7 @@ final class FavoriteService extends AbstractService
     /**
      * @throws AuthenticationRequired
      */
-    public function removeDeclinationToUserFavorites(int $declinationId) : void
+    public function removeDeclinationToUserFavorites(string $declinationId) : void
     {
         $this->client->mustBeAuthenticated();
         $this->client->rawRequest('delete', 'user/favorites/declinations/'.$declinationId);

--- a/tests/Favorite/FavoriteServiceTest.php
+++ b/tests/Favorite/FavoriteServiceTest.php
@@ -26,49 +26,49 @@ final class FavoriteServiceTest extends ApiTestCase
         parent::setUp();
         $this->favService = $this->buildFavoriteService();
 
-        $this->favService->addDeclinationToUserFavorites(1);
+        $this->favService->addDeclinationToUserFavorites('1');
     }
 
     public function testAddProductToFavorite()
     {
-        $this->favService->addDeclinationToUserFavorites(2);
+        $this->favService->addDeclinationToUserFavorites('2');
 
-        $this->assertTrue($this->favService->isInFavorites(2));
+        $this->assertTrue($this->favService->isInFavorites('2'));
     }
 
     public function testAddFavProductToFavorite()
     {
         $this->expectException(FavoriteAlreadyExist::class);
 
-        $this->favService->addDeclinationToUserFavorites(1);
+        $this->favService->addDeclinationToUserFavorites('1');
     }
 
     public function testAddNotProductToFavorite()
     {
         $this->expectException(CannotFavoriteDisabledOrInexistentDeclination::class);
 
-        $this->favService->addDeclinationToUserFavorites(404);
+        $this->favService->addDeclinationToUserFavorites('404');
     }
 
     public function testIsNotFavorite()
     {
-        $isFavorite = $this->favService->isInFavorites(3);
+        $isFavorite = $this->favService->isInFavorites('3');
 
         $this->assertFalse($isFavorite);
     }
 
     public function testIsFavorite()
     {
-        $isFavorite = $this->favService->isInFavorites(1);
+        $isFavorite = $this->favService->isInFavorites('1');
 
         $this->assertTrue($isFavorite);
     }
 
     public function testGetAll()
     {
-        $this->favService->addDeclinationToUserFavorites(2);
+        $this->favService->addDeclinationToUserFavorites('2');
         $favorites = $this->favService->getAll();
-        $this->favService->removeDeclinationToUserFavorites(2);
+        $this->favService->removeDeclinationToUserFavorites('2');
 
         $this->assertTrue(is_array($favorites));
         $this->assertCount(2, $favorites);
@@ -80,15 +80,15 @@ final class FavoriteServiceTest extends ApiTestCase
 
     public function testRemoveProductFromFavorite()
     {
-        $this->favService->removeDeclinationToUserFavorites(1);
+        $this->favService->removeDeclinationToUserFavorites('1');
 
-        $this->assertFalse($this->favService->isInFavorites(1));
+        $this->assertFalse($this->favService->isInFavorites('1'));
     }
 
     public function tearDown() :void
     {
-        $this->favService->removeDeclinationToUserFavorites(1);
-        $this->favService->removeDeclinationToUserFavorites(2);
+        $this->favService->removeDeclinationToUserFavorites('1');
+        $this->favService->removeDeclinationToUserFavorites('2');
         parent::tearDown();
     }
 


### PR DESCRIPTION
## Checklist

- [x] Changelog updated

#### Problème:
Le paramètre `$declinationId` était demandé en `int` et donc, ça ne fonctionnait que pour les produits à déclinaison unique.

#### Solution :
Paramètre passé en `string`