### PR TITLE
Fix in favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### Bugfixes
 
-- `\Wizaplace\Favorite\FavoriteService::isInFavorites` now properly returns `true` or `false` instead of `false` everytime when using it with a declinationId
-
 ## 0.7.2
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bugfixes
 
+- `\Wizaplace\Favorite\FavoriteService::isInFavorites` now properly returns `true` or `false` instead of `false` everytime when using it with a declinationId
+
 ## 0.7.2
 
 ### New features

--- a/src/Favorite/FavoriteService.php
+++ b/src/Favorite/FavoriteService.php
@@ -47,8 +47,7 @@ final class FavoriteService extends AbstractService
         $isInFavorites = false;
         if ($results['count'] > 0) {
             foreach ($results['_embedded']['favorites'] as $result) {
-                $declination = explode('_', $result);
-                if ($declination[0] == $declinationId) {
+                if ($result == $declinationId) {
                     $isInFavorites = true;
                     break;
                 }

--- a/tests/Favorite/FavoriteServiceTest.php
+++ b/tests/Favorite/FavoriteServiceTest.php
@@ -12,7 +12,6 @@ use Wizaplace\Favorite\Exception\CannotFavoriteDisabledOrInexistentDeclination;
 use Wizaplace\Favorite\Exception\FavoriteAlreadyExist;
 use Wizaplace\Favorite\FavoriteService;
 use Wizaplace\Tests\ApiTestCase;
-use Wizaplace\User\ApiKey;
 
 final class FavoriteServiceTest extends ApiTestCase
 {
@@ -31,9 +30,9 @@ final class FavoriteServiceTest extends ApiTestCase
 
     public function testAddProductToFavorite()
     {
-        $this->favService->addDeclinationToUserFavorites('2');
+        $this->favService->addDeclinationToUserFavorites('2_9_1');
 
-        $this->assertTrue($this->favService->isInFavorites('2'));
+        $this->assertTrue($this->favService->isInFavorites('2_9_1'));
     }
 
     public function testAddFavProductToFavorite()
@@ -59,7 +58,7 @@ final class FavoriteServiceTest extends ApiTestCase
 
     public function testIsFavorite()
     {
-        $isFavorite = $this->favService->isInFavorites('1');
+        $isFavorite = $this->favService->isInFavorites('1_0');
 
         $this->assertTrue($isFavorite);
     }

--- a/tests/Favorite/FavoriteServiceTest/testAddFavProductToFavorite.yml
+++ b/tests/Favorite/FavoriteServiceTest/testAddFavProductToFavorite.yml
@@ -6,7 +6,7 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
             VCR-index: '0'
             Accept: null
@@ -16,14 +16,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:23 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:12 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: a9d5a5
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/a9d5a5'
+            X-Debug-Token: 05d896
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/05d896'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA"}'
+        body: '{"id":2,"apiKey":"kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz"}'
 -
     request:
         method: POST
@@ -32,8 +32,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,11 +42,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:23 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:13 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: edc424
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/edc424'
+            X-Debug-Token: 95711e
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/95711e'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -58,8 +58,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '2'
             Accept: null
     response:
@@ -68,11 +68,11 @@
             code: '409'
             message: Conflict
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:23 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:13 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 819eab
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/819eab'
+            X-Debug-Token: 541ec4
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/541ec4'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -83,8 +83,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '3'
             Accept: null
     response:
@@ -93,11 +93,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:24 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:13 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: f59cd5
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/f59cd5'
+            X-Debug-Token: 7579a6
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/7579a6'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -107,8 +107,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '4'
             Accept: null
     response:
@@ -117,10 +117,10 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:24 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:13 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: '0e3351'
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/0e3351'
+            X-Debug-Token: a81f71
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/a81f71'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'

--- a/tests/Favorite/FavoriteServiceTest/testAddNotProductToFavorite.yml
+++ b/tests/Favorite/FavoriteServiceTest/testAddNotProductToFavorite.yml
@@ -6,7 +6,7 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
             VCR-index: '0'
             Accept: null
@@ -16,14 +16,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:24 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:14 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 1eca62
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/1eca62'
+            X-Debug-Token: 56d9a7
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/56d9a7'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA"}'
+        body: '{"id":2,"apiKey":"kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz"}'
 -
     request:
         method: POST
@@ -32,8 +32,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,11 +42,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:25 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:14 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 27a5f9
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/27a5f9'
+            X-Debug-Token: 79c1a9
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/79c1a9'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -58,8 +58,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '2'
             Accept: null
     response:
@@ -68,11 +68,11 @@
             code: '400'
             message: 'Bad Request'
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:25 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:14 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 5ef9f2
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/5ef9f2'
+            X-Debug-Token: 2f5ff3
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/2f5ff3'
             Content-Length: '2'
             Connection: close
             Content-Type: application/json
@@ -84,8 +84,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '3'
             Accept: null
     response:
@@ -94,11 +94,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:25 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:14 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: a6e8c8
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/a6e8c8'
+            X-Debug-Token: 45996a
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/45996a'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -108,8 +108,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.7-1+ubuntu16.04.1+deb.sury.org+1'
-            Authorization: 'token bCKUC90uoAifOx7tc94dBUQSnGOrp4DAqX4bGDbA'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '4'
             Accept: null
     response:
@@ -118,10 +118,10 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Tue, 11 Jul 2017 13:15:25 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:15 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 52546e
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/52546e'
+            X-Debug-Token: 589c8f
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/589c8f'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'

--- a/tests/Favorite/FavoriteServiceTest/testAddProductToFavorite.yml
+++ b/tests/Favorite/FavoriteServiceTest/testAddProductToFavorite.yml
@@ -6,7 +6,7 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
             VCR-index: '0'
             Accept: null
@@ -16,14 +16,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:44 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:10 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 64ee75
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/64ee75'
+            X-Debug-Token: '018099'
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/018099'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi"}'
+        body: '{"id":2,"apiKey":"kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz"}'
 -
     request:
         method: POST
@@ -32,8 +32,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,24 +42,24 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:44 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:11 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 44dcf0
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/44dcf0'
+            X-Debug-Token: '67e481'
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/67e481'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
 -
     request:
         method: POST
-        url: 'http://wizaplace.loc/api/v1/user/favorites/declinations/2'
+        url: 'http://wizaplace.loc/api/v1/user/favorites/declinations/2_9_1'
         headers:
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '2'
             Accept: null
     response:
@@ -68,11 +68,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:45 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:11 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: f9372d
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/f9372d'
+            X-Debug-Token: 5d8be9
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/5d8be9'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -83,8 +83,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '3'
             Accept: null
     response:
@@ -93,14 +93,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:45 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:11 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 4d2e7d
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/4d2e7d'
-            Content-Length: '61'
+            X-Debug-Token: 548d80
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/548d80'
+            Content-Length: '63'
             Content-Type: application/json
-        body: '{"total":2,"count":2,"_embedded":{"favorites":["1_0","2_0"]}}'
+        body: '{"total":2,"count":2,"_embedded":{"favorites":["1_0","2_9_1"]}}'
 -
     request:
         method: DELETE
@@ -108,8 +108,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '4'
             Accept: null
     response:
@@ -118,11 +118,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:45 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:12 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 3caf89
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/3caf89'
+            X-Debug-Token: e6bf69
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/e6bf69'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -132,8 +132,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '5'
             Accept: null
     response:
@@ -142,10 +142,10 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:45 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:12 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 66ac9d
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/66ac9d'
+            X-Debug-Token: 7d4eb3
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/7d4eb3'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'

--- a/tests/Favorite/FavoriteServiceTest/testGetAll.yml
+++ b/tests/Favorite/FavoriteServiceTest/testGetAll.yml
@@ -6,7 +6,7 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
             VCR-index: '0'
             Accept: null
@@ -16,14 +16,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Fri, 11 Aug 2017 08:57:36 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:17 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: '5e8953'
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/5e8953'
+            X-Debug-Token: 5ceff8
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/5ceff8'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi"}'
+        body: '{"id":2,"apiKey":"kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz"}'
 -
     request:
         method: POST
@@ -32,8 +32,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,11 +42,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Fri, 11 Aug 2017 08:57:39 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:18 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: bb5f3e
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/bb5f3e'
+            X-Debug-Token: b8d57d
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/b8d57d'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -58,8 +58,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '2'
             Accept: null
     response:
@@ -68,11 +68,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Fri, 11 Aug 2017 08:57:39 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:18 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: e6b44e
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/e6b44e'
+            X-Debug-Token: 4727ec
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/4727ec'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -83,8 +83,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '3'
             Accept: null
     response:
@@ -93,14 +93,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Fri, 11 Aug 2017 08:57:40 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:18 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 85deb1
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/85deb1'
-            Content-Length: '854'
+            X-Debug-Token: '842028'
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/842028'
+            Content-Length: '951'
             Content-Type: application/json
-        body: '{"total":2,"count":2,"_embedded":{"favorites":[{"id":"1_0","productId":1,"name":"optio corporis similique voluptatum","slug":"test-product-slug","code":"6086375420678","crossedOutPrice":null,"prices":{"priceWithoutVat":19.59,"priceWithTaxes":20,"vat":0.41},"amount":14,"affiliateLink":null,"mainImage":null,"options":[],"categoryPath":[{"id":3,"name":"Informatique","slug":"informatique"}],"company":{"id":5,"name":"Test company","slug":"test-company","image":null}},{"id":"2_0","productId":2,"name":"\u00c9cran","slug":"ecran","code":"0832868764141","crossedOutPrice":null,"prices":{"priceWithoutVat":19.59,"priceWithTaxes":20,"vat":0.41},"amount":13,"affiliateLink":null,"mainImage":null,"options":[],"categoryPath":[{"id":3,"name":"Informatique","slug":"informatique"}],"company":{"id":6,"name":"Test company","slug":"test-company-2","image":null}}]}}'
+        body: '{"total":2,"count":2,"_embedded":{"favorites":[{"id":"1_0","productId":1,"name":"optio corporis similique voluptatum","slug":"test-product-slug","code":"6086375420678","crossedOutPrice":null,"prices":{"priceWithoutVat":19.59,"priceWithTaxes":20,"vat":0.41},"amount":15,"affiliateLink":null,"mainImage":null,"options":[],"categoryPath":[{"id":3,"name":"Informatique","slug":"informatique"}],"company":{"id":7,"name":"Test company","slug":"test-company","isProfessional":true,"image":null}},{"id":"2_9_1","productId":2,"name":"\u00c9cran","slug":"ecran","code":"size_13","crossedOutPrice":null,"prices":{"priceWithoutVat":15.18,"priceWithTaxes":15.5,"vat":0.32},"amount":10,"affiliateLink":null,"mainImage":null,"options":[{"id":9,"name":"size","variantId":1,"variantName":"13"}],"categoryPath":[{"id":3,"name":"Informatique","slug":"informatique"}],"company":{"id":8,"name":"Test company","slug":"test-company-2","isProfessional":true,"image":null}}]}}'
 -
     request:
         method: DELETE
@@ -108,8 +108,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '4'
             Accept: null
     response:
@@ -118,11 +118,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Fri, 11 Aug 2017 08:57:40 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:19 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: c2a4a1
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/c2a4a1'
+            X-Debug-Token: 1d587e
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/1d587e'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -132,8 +132,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '5'
             Accept: null
     response:
@@ -142,11 +142,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Fri, 11 Aug 2017 08:57:40 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:19 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: '991599'
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/991599'
+            X-Debug-Token: 25973a
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/25973a'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -156,8 +156,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '6'
             Accept: null
     response:
@@ -166,10 +166,10 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Fri, 11 Aug 2017 08:57:40 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:19 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: b71285
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/b71285'
+            X-Debug-Token: 7c953c
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/7c953c'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'

--- a/tests/Favorite/FavoriteServiceTest/testIsFavorite.yml
+++ b/tests/Favorite/FavoriteServiceTest/testIsFavorite.yml
@@ -6,7 +6,7 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
             VCR-index: '0'
             Accept: null
@@ -16,14 +16,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:46 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:16 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: d3d0b6
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/d3d0b6'
+            X-Debug-Token: c49f21
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/c49f21'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi"}'
+        body: '{"id":2,"apiKey":"kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz"}'
 -
     request:
         method: POST
@@ -32,8 +32,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,11 +42,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:47 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:16 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: a64bf3
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/a64bf3'
+            X-Debug-Token: 03554a
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/03554a'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -57,8 +57,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '2'
             Accept: null
     response:
@@ -67,11 +67,11 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:47 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:17 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 1b90b3
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/1b90b3'
+            X-Debug-Token: e7f163
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/e7f163'
             Content-Length: '55'
             Content-Type: application/json
         body: '{"total":1,"count":1,"_embedded":{"favorites":["1_0"]}}'
@@ -82,8 +82,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '3'
             Accept: null
     response:
@@ -92,11 +92,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:47 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:17 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 8c8cf6
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/8c8cf6'
+            X-Debug-Token: c460f1
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/c460f1'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -106,8 +106,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '4'
             Accept: null
     response:
@@ -116,10 +116,10 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:47 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:17 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: '475479'
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/475479'
+            X-Debug-Token: 62dc02
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/62dc02'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'

--- a/tests/Favorite/FavoriteServiceTest/testIsNotFavorite.yml
+++ b/tests/Favorite/FavoriteServiceTest/testIsNotFavorite.yml
@@ -6,7 +6,7 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
             VCR-index: '0'
             Accept: null
@@ -16,14 +16,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:45 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:15 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: fe35f2
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/fe35f2'
+            X-Debug-Token: 76c0a1
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/76c0a1'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi"}'
+        body: '{"id":2,"apiKey":"kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz"}'
 -
     request:
         method: POST
@@ -32,8 +32,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,11 +42,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:46 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:15 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 9fe056
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/9fe056'
+            X-Debug-Token: 01c86d
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/01c86d'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -57,8 +57,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '2'
             Accept: null
     response:
@@ -67,11 +67,11 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:46 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:15 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 4925fd
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/4925fd'
+            X-Debug-Token: 7de653
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/7de653'
             Content-Length: '55'
             Content-Type: application/json
         body: '{"total":1,"count":1,"_embedded":{"favorites":["1_0"]}}'
@@ -82,8 +82,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '3'
             Accept: null
     response:
@@ -92,11 +92,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:46 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:16 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: fe6a94
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/fe6a94'
+            X-Debug-Token: d949c9
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/d949c9'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -106,8 +106,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '4'
             Accept: null
     response:
@@ -116,10 +116,10 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:46 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:16 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: b2e223
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/b2e223'
+            X-Debug-Token: efb7e5
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/efb7e5'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'

--- a/tests/Favorite/FavoriteServiceTest/testRemoveProductFromFavorite.yml
+++ b/tests/Favorite/FavoriteServiceTest/testRemoveProductFromFavorite.yml
@@ -6,7 +6,7 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
             VCR-index: '0'
             Accept: null
@@ -16,14 +16,14 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:47 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:19 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 18ba47
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/18ba47'
+            X-Debug-Token: '682861'
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/682861'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi"}'
+        body: '{"id":2,"apiKey":"kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz"}'
 -
     request:
         method: POST
@@ -32,8 +32,8 @@
             Host: wizaplace.loc
             Content-Length: '0'
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,11 +42,11 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:48 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:20 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: f18e8a
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/f18e8a'
+            X-Debug-Token: '889055'
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/889055'
             Content-Length: '2'
             Content-Type: application/json
         body: '""'
@@ -57,8 +57,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '2'
             Accept: null
     response:
@@ -67,11 +67,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:48 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:20 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 7aecc0
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/7aecc0'
+            X-Debug-Token: 79fb86
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/79fb86'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -81,8 +81,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '3'
             Accept: null
     response:
@@ -91,11 +91,11 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:48 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:20 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: cc94ec
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/cc94ec'
+            X-Debug-Token: eab33a
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/eab33a'
             Content-Length: '50'
             Content-Type: application/json
         body: '{"total":0,"count":0,"_embedded":{"favorites":[]}}'
@@ -106,8 +106,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '4'
             Accept: null
     response:
@@ -116,11 +116,11 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:48 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:20 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 1a26ba
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/1a26ba'
+            X-Debug-Token: 05da92
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/05da92'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'
 -
@@ -130,8 +130,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.1.7'
-            Authorization: 'token NhCc3un4bn7jSr4QJmqGHBM0zDuTkRkie8jqJKAi'
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.47.0 PHP/7.1.6-1~ubuntu16.04.1+deb.sury.org+1'
+            Authorization: 'token kJS7LCymbhgCbU2IqNjHITRHSCs1Q7Agl8eZmyBz'
             VCR-index: '5'
             Accept: null
     response:
@@ -140,10 +140,10 @@
             code: '204'
             message: 'No Content'
         headers:
-            Date: 'Mon, 07 Aug 2017 12:38:48 GMT'
+            Date: 'Mon, 04 Sep 2017 14:05:21 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 53092f
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/53092f'
+            X-Debug-Token: 9285ba
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/9285ba'
             Content-Length: '0'
             Content-Type: 'text/html; charset=UTF-8'


### PR DESCRIPTION
## Checklist

- [x] Changelog updated

#### Problème:
Lorsqu'on essaie de savoir si une déclinaison fait partie des favoris de l'utilisateurs à partir d'un produit à plusieurs déclinaisons, on avait `false` comme réponse à chaque fois.

#### Solution:
Enlevé l' `explode` qui faisait que l'on comparait l'id des produits et non des déclinaisons