### PR TITLE
OrderStatus enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `\Wizaplace\Favorite\FavoriteService::isInFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
 - `\Wizaplace\Favorite\FavoriteService::addDeclinationToUserFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
 - `\Wizaplace\Favorite\FavoriteService::removeDeclinationToUserFavorites` is now taking a `string $declinationId` parameter instead of a `int $declinationId` one.
+- `\Wizaplace\Order\Order::getStatus` is now returning an `\Wizaplace\Order\OrderStatus` instead of a string.
 
 ### New features
 

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -19,7 +19,7 @@ final class Order
     private $subtotal;
     /** @var \DateTimeImmutable */
     private $timestamp;
-    /** @var string */
+    /** @var OrderStatus */
     private $status;
     /** @var string */
     private $shippingName;
@@ -38,7 +38,7 @@ final class Order
         $this->total = $data['total'];
         $this->subtotal = $data['subtotal'];
         $this->timestamp = new \DateTimeImmutable('@'.$data['timestamp']);
-        $this->status = $data['status'];
+        $this->status = new OrderStatus($data['status']);
         $this->shippingName = $data['shippingName'];
         $this->shippingAddress = new ShippingAddress($data['shippingAddress']);
         $this->orderItems = array_map(static function (array $orderItemData) : OrderItem {
@@ -71,7 +71,7 @@ final class Order
         return $this->timestamp;
     }
 
-    public function getStatus(): string
+    public function getStatus(): OrderStatus
     {
         return $this->status;
     }

--- a/src/Order/OrderStatus.php
+++ b/src/Order/OrderStatus.php
@@ -21,8 +21,6 @@ use MyCLabs\Enum\Enum;
  * @method static OrderStatus UNPAID()
  * @method static OrderStatus REFUNDED()
  * @method static OrderStatus CANCELED()
- * @method static OrderStatus INCOMPLETED()
- * @method static OrderStatus PARENT_ORDER()
  */
 final class OrderStatus extends Enum
 {
@@ -37,6 +35,4 @@ final class OrderStatus extends Enum
     private const UNPAID = "UNPAID";
     private const REFUNDED = "REFUNDED";
     private const CANCELED = "CANCELED";
-    private const INCOMPLETED = "INCOMPLETED";
-    private const PARENT_ORDER = "PARENT_ORDER";
 }

--- a/src/Order/OrderStatus.php
+++ b/src/Order/OrderStatus.php
@@ -9,6 +9,21 @@ namespace Wizaplace\Order;
 
 use MyCLabs\Enum\Enum;
 
+/**
+ * @method static OrderStatus STANDBY_BILLING()
+ * @method static OrderStatus STANDBY_VENDOR()
+ * @method static OrderStatus PROCESSING_SHIPPING()
+ * @method static OrderStatus PROCESSED()
+ * @method static OrderStatus COMPLETED()
+ * @method static OrderStatus BILLING_FAILED()
+ * @method static OrderStatus VENDOR_DECLINED()
+ * @method static OrderStatus STANDBY_SUPPLYING()
+ * @method static OrderStatus UNPAID()
+ * @method static OrderStatus REFUNDED()
+ * @method static OrderStatus CANCELED()
+ * @method static OrderStatus INCOMPLETED()
+ * @method static OrderStatus PARENT_ORDER()
+ */
 final class OrderStatus extends Enum
 {
     private const STANDBY_BILLING = "STANDBY_BILLING";

--- a/src/Order/OrderStatus.php
+++ b/src/Order/OrderStatus.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright   Copyright (c) Wizacha
+ * @license     Proprietary
+ */
+declare(strict_types = 1);
+
+namespace Wizaplace\Order;
+
+use MyCLabs\Enum\Enum;
+
+final class OrderStatus extends Enum
+{
+    private const STANDBY_BILLING = "STANDBY_BILLING";
+    private const STANDBY_VENDOR = "STANDBY_VENDOR";
+    private const PROCESSING_SHIPPING = "PROCESSING_SHIPPING";
+    private const PROCESSED = "PROCESSED";
+    private const COMPLETED = "COMPLETED";
+    private const BILLING_FAILED = "BILLING_FAILED";
+    private const VENDOR_DECLINED = "VENDOR_DECLINED";
+    private const STANDBY_SUPPLYING = "STANDBY_SUPPLYING";
+    private const UNPAID = "UNPAID";
+    private const REFUNDED = "REFUNDED";
+    private const CANCELED = "CANCELED";
+    private const INCOMPLETED = "INCOMPLETED";
+    private const PARENT_ORDER = "PARENT_ORDER";
+}

--- a/tests/Basket/BasketServiceTest.php
+++ b/tests/Basket/BasketServiceTest.php
@@ -91,7 +91,7 @@ final class BasketServiceTest extends ApiTestCase
         $this->assertSame($orders[0]['id'], $order->getId());
         $this->assertSame(5, $order->getCompanyId());
         $this->assertSame('TNT Express', $order->getShippingName());
-        $this->assertSame(OrderStatus::STANDBY_BILLING(), $order->getStatus());
+        $this->assertEquals(OrderStatus::STANDBY_BILLING(), $order->getStatus());
         $this->assertGreaterThan(1500000000, $order->getTimestamp()->getTimestamp());
         $this->assertSame(40.0, $order->getTotal());
         $this->assertSame(40.0, $order->getSubtotal());

--- a/tests/Basket/BasketServiceTest.php
+++ b/tests/Basket/BasketServiceTest.php
@@ -9,6 +9,7 @@ namespace Wizaplace\Tests\Basket;
 
 use Wizaplace\Basket\BasketService;
 use Wizaplace\Order\OrderService;
+use Wizaplace\Order\OrderStatus;
 use Wizaplace\Tests\ApiTestCase;
 
 /**
@@ -90,7 +91,7 @@ final class BasketServiceTest extends ApiTestCase
         $this->assertSame($orders[0]['id'], $order->getId());
         $this->assertSame(5, $order->getCompanyId());
         $this->assertSame('TNT Express', $order->getShippingName());
-        $this->assertSame('STANDBY_BILLING', $order->getStatus());
+        $this->assertSame(OrderStatus::STANDBY_BILLING(), $order->getStatus());
         $this->assertGreaterThan(1500000000, $order->getTimestamp()->getTimestamp());
         $this->assertSame(40.0, $order->getTotal());
         $this->assertSame(40.0, $order->getSubtotal());

--- a/tests/Order/OrderServiceTest.php
+++ b/tests/Order/OrderServiceTest.php
@@ -10,6 +10,7 @@ namespace Wizaplace\Tests\Order;
 use Wizaplace\Authentication\AuthenticationRequired;
 use Wizaplace\Order\CreateOrderReturn;
 use Wizaplace\Order\OrderService;
+use Wizaplace\Order\OrderStatus;
 use Wizaplace\Order\ReturnItem;
 use Wizaplace\Tests\ApiTestCase;
 
@@ -23,6 +24,7 @@ final class OrderServiceTest extends ApiTestCase
         $order = $this->buildOrderService()->getOrder(1);
 
         $this->assertSame(1, $order->getId());
+        $this->assertEquals(OrderStatus::STANDBY_BILLING(), $order->getStatus());
     }
 
     public function testCreateOrderReturn()


### PR DESCRIPTION
## Checklist

- [x] Changelog updated

Issue : #124 

`Order->getStatus()` now returns an enum ( `OrderStatus` )