### PR TITLE
Utilisation du nouveau champ 'authorId' des messages pour remplir 'isAuthor'

### DIFF
--- a/src/Discussion/DiscussionService.php
+++ b/src/Discussion/DiscussionService.php
@@ -104,7 +104,7 @@ final class DiscussionService extends AbstractService
             $userId = $this->client->getApiKey()->getId();
 
             return array_map(static function (array $messageData) use ($userId) : Message {
-                $messageData['isAuthor'] = ($messageData['author'] === $userId);
+                $messageData['isAuthor'] = ($messageData['authorId'] === $userId);
 
                 return new Message($messageData);
             }, $messages);
@@ -125,7 +125,7 @@ final class DiscussionService extends AbstractService
 
         try {
             $messageData = $this->client->post('discussions/'.$discussionId.'/messages', ['json' => ['content' => $content]]);
-            $messageData['isAuthor'] = ($messageData['author'] === $this->client->getApiKey()->getId());
+            $messageData['isAuthor'] = ($messageData['authorId'] === $this->client->getApiKey()->getId());
 
             return new Message($messageData);
         } catch (ClientException $e) {

--- a/tests/Discussion/DiscussionServiceTest/testGetMessages.yml
+++ b/tests/Discussion/DiscussionServiceTest/testGetMessages.yml
@@ -13,95 +13,14 @@
     response:
         status:
             http_version: '1.1'
-            code: '200'
-            message: OK
+            code: '401'
+            message: Unauthorized
         headers:
-            Date: 'Tue, 12 Sep 2017 14:59:21 GMT'
+            Date: 'Fri, 15 Sep 2017 13:52:44 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 063cb3
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/063cb3'
-            Content-Length: '61'
-            Content-Type: application/json
-        body: '{"id":7,"apiKey":"cW+Q3EG696n\/w2pW79g3Qfs24KtyKl5jibBty5vH"}'
--
-    request:
-        method: POST
-        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
-        headers:
-            Host: wizaplace.loc
-            Expect: null
-            Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
-            Content-Type: application/json
-            Authorization: 'token cW+Q3EG696n/w2pW79g3Qfs24KtyKl5jibBty5vH'
-            VCR-index: '1'
-            Accept: null
-        body: '{"content":"This is a test message"}'
-    response:
-        status:
-            http_version: '1.1'
-            code: '201'
-            message: Created
-        headers:
-            Date: 'Tue, 12 Sep 2017 14:59:21 GMT'
-            Server: 'Apache/2.4.10 (Debian)'
-            Cache-Control: 'no-cache, private'
-            X-Debug-Token: 600fe8
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/600fe8'
-            Content-Length: '82'
-            Content-Type: application/json
-        body: '{"content":"This is a test message","author":7,"date":"2017-09-12T16:59:21+02:00"}'
--
-    request:
-        method: POST
-        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
-        headers:
-            Host: wizaplace.loc
-            Expect: null
-            Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
-            Content-Type: application/json
-            Authorization: 'token cW+Q3EG696n/w2pW79g3Qfs24KtyKl5jibBty5vH'
-            VCR-index: '2'
-            Accept: null
-        body: '{"content":"This is an other test message"}'
-    response:
-        status:
-            http_version: '1.1'
-            code: '201'
-            message: Created
-        headers:
-            Date: 'Tue, 12 Sep 2017 14:59:22 GMT'
-            Server: 'Apache/2.4.10 (Debian)'
-            Cache-Control: 'no-cache, private'
-            X-Debug-Token: 5399df
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/5399df'
-            Content-Length: '89'
-            Content-Type: application/json
-        body: '{"content":"This is an other test message","author":7,"date":"2017-09-12T16:59:22+02:00"}'
--
-    request:
-        method: GET
-        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
-        headers:
-            Host: wizaplace.loc
-            Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
-            Authorization: 'token cW+Q3EG696n/w2pW79g3Qfs24KtyKl5jibBty5vH'
-            VCR-index: '3'
-            Accept: null
-    response:
-        status:
-            http_version: '1.1'
-            code: '200'
-            message: OK
-        headers:
-            Date: 'Tue, 12 Sep 2017 14:59:22 GMT'
-            Server: 'Apache/2.4.10 (Debian)'
-            Cache-Control: 'no-cache, private'
-            X-Debug-Token: e585b8
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/e585b8'
-            Content-Length: '174'
-            Content-Type: application/json
-        body: '[{"content":"This is a test message","author":7,"date":"2017-09-12T16:59:21+02:00"},{"content":"This is an other test message","author":7,"date":"2017-09-12T16:59:22+02:00"}]'
+            WWW-Authenticate: 'Basic realm="Secured Area"'
+            X-Debug-Token: 1d676e
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/1d676e'
+            Content-Length: '0'
+            Content-Type: 'text/html; charset=UTF-8'

--- a/tests/Discussion/DiscussionServiceTest/testGetMessages.yml
+++ b/tests/Discussion/DiscussionServiceTest/testGetMessages.yml
@@ -13,14 +13,95 @@
     response:
         status:
             http_version: '1.1'
-            code: '401'
-            message: Unauthorized
+            code: '200'
+            message: OK
         headers:
-            Date: 'Fri, 15 Sep 2017 13:52:44 GMT'
+            Date: 'Mon, 18 Sep 2017 09:48:32 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            WWW-Authenticate: 'Basic realm="Secured Area"'
-            X-Debug-Token: 1d676e
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/1d676e'
-            Content-Length: '0'
-            Content-Type: 'text/html; charset=UTF-8'
+            X-Debug-Token: 8fc5c0
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/8fc5c0'
+            Content-Length: '61'
+            Content-Type: application/json
+        body: '{"id":7,"apiKey":"\/kdxCGlfnQA0cFiRdQy5bHiiE7+mngKvCEh0mpB2"}'
+-
+    request:
+        method: POST
+        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
+        headers:
+            Host: wizaplace.loc
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
+            Content-Type: application/json
+            Authorization: 'token /kdxCGlfnQA0cFiRdQy5bHiiE7+mngKvCEh0mpB2'
+            VCR-index: '1'
+            Accept: null
+        body: '{"content":"This is a test message"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            Date: 'Mon, 18 Sep 2017 09:48:32 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            X-Debug-Token: 4dfe8a
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/4dfe8a'
+            Content-Length: '110'
+            Content-Type: application/json
+        body: '{"content":"This is a test message","author":"Michael Jordan","authorId":7,"date":"2017-09-18T11:48:32+02:00"}'
+-
+    request:
+        method: POST
+        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
+        headers:
+            Host: wizaplace.loc
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
+            Content-Type: application/json
+            Authorization: 'token /kdxCGlfnQA0cFiRdQy5bHiiE7+mngKvCEh0mpB2'
+            VCR-index: '2'
+            Accept: null
+        body: '{"content":"This is an other test message"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            Date: 'Mon, 18 Sep 2017 09:48:33 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            X-Debug-Token: 17f4db
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/17f4db'
+            Content-Length: '117'
+            Content-Type: application/json
+        body: '{"content":"This is an other test message","author":"Michael Jordan","authorId":7,"date":"2017-09-18T11:48:33+02:00"}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
+            Authorization: 'token /kdxCGlfnQA0cFiRdQy5bHiiE7+mngKvCEh0mpB2'
+            VCR-index: '3'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Mon, 18 Sep 2017 09:48:33 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            X-Debug-Token: 08fe84
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/08fe84'
+            Content-Length: '230'
+            Content-Type: application/json
+        body: '[{"content":"This is a test message","author":"Michael Jordan","authorId":7,"date":"2017-09-18T11:48:32+02:00"},{"content":"This is an other test message","author":"Michael Jordan","authorId":7,"date":"2017-09-18T11:48:33+02:00"}]'

--- a/tests/Discussion/DiscussionServiceTest/testPostMessage.yml
+++ b/tests/Discussion/DiscussionServiceTest/testPostMessage.yml
@@ -13,14 +13,42 @@
     response:
         status:
             http_version: '1.1'
-            code: '401'
-            message: Unauthorized
+            code: '200'
+            message: OK
         headers:
-            Date: 'Fri, 15 Sep 2017 13:56:28 GMT'
+            Date: 'Mon, 18 Sep 2017 09:48:54 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            WWW-Authenticate: 'Basic realm="Secured Area"'
-            X-Debug-Token: f086d1
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/f086d1'
-            Content-Length: '0'
-            Content-Type: 'text/html; charset=UTF-8'
+            X-Debug-Token: 8e3f8c
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/8e3f8c'
+            Content-Length: '60'
+            Content-Type: application/json
+        body: '{"id":7,"apiKey":"bR6BnmfT6s1pXxP5ZyyArYKYOSGcET+rtYg2TW93"}'
+-
+    request:
+        method: POST
+        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
+        headers:
+            Host: wizaplace.loc
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
+            Content-Type: application/json
+            Authorization: 'token bR6BnmfT6s1pXxP5ZyyArYKYOSGcET+rtYg2TW93'
+            VCR-index: '1'
+            Accept: null
+        body: '{"content":"This is a test message"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            Date: 'Mon, 18 Sep 2017 09:48:54 GMT'
+            Server: 'Apache/2.4.10 (Debian)'
+            Cache-Control: 'no-cache, private'
+            X-Debug-Token: 1ac25c
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/1ac25c'
+            Content-Length: '110'
+            Content-Type: application/json
+        body: '{"content":"This is a test message","author":"Michael Jordan","authorId":7,"date":"2017-09-18T11:48:55+02:00"}'

--- a/tests/Discussion/DiscussionServiceTest/testPostMessage.yml
+++ b/tests/Discussion/DiscussionServiceTest/testPostMessage.yml
@@ -13,42 +13,14 @@
     response:
         status:
             http_version: '1.1'
-            code: '200'
-            message: OK
+            code: '401'
+            message: Unauthorized
         headers:
-            Date: 'Tue, 12 Sep 2017 14:59:10 GMT'
+            Date: 'Fri, 15 Sep 2017 13:56:28 GMT'
             Server: 'Apache/2.4.10 (Debian)'
             Cache-Control: 'no-cache, private'
-            X-Debug-Token: 501ef2
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/501ef2'
-            Content-Length: '60'
-            Content-Type: application/json
-        body: '{"id":7,"apiKey":"vqNlwJzMJWDvlTmYmAkDDqRkg2HfDLwedTBgD5a+"}'
--
-    request:
-        method: POST
-        url: 'http://wizaplace.loc/api/v1/discussions/1/messages'
-        headers:
-            Host: wizaplace.loc
-            Expect: null
-            Accept-Encoding: null
-            User-Agent: 'GuzzleHttp/6.2.1 curl/7.38.0 PHP/7.1.9'
-            Content-Type: application/json
-            Authorization: 'token vqNlwJzMJWDvlTmYmAkDDqRkg2HfDLwedTBgD5a+'
-            VCR-index: '1'
-            Accept: null
-        body: '{"content":"This is a test message"}'
-    response:
-        status:
-            http_version: '1.1'
-            code: '201'
-            message: Created
-        headers:
-            Date: 'Tue, 12 Sep 2017 14:59:10 GMT'
-            Server: 'Apache/2.4.10 (Debian)'
-            Cache-Control: 'no-cache, private'
-            X-Debug-Token: d31627
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/d31627'
-            Content-Length: '82'
-            Content-Type: application/json
-        body: '{"content":"This is a test message","author":7,"date":"2017-09-12T16:59:11+02:00"}'
+            WWW-Authenticate: 'Basic realm="Secured Area"'
+            X-Debug-Token: f086d1
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/f086d1'
+            Content-Length: '0'
+            Content-Type: 'text/html; charset=UTF-8'


### PR DESCRIPTION
Dois-je ajouter les deux champs exposés par l'API dans le SDK :
- `authorId` dans les _messages_,
- `recipientId` dans les _discussions_ ?

J'ai un doute car le champ `author`, pourtant disponible dans l'API, n'est pas exposé dans les _messages_.

Que fais-je ?