### PR TITLE
SearchProductAttribute::getValues now returns an array of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### BREAKING CHANGES
 
+- `\Wizaplace\SDK\Catalog\SearchProductAttribute::getValues` now returns an array of `\Wizaplace\SDK\Catalog\ProductAttributeValue` instead of an array of associative arrays
+
 ### New features
 
 ### Bugfixes

--- a/src/Catalog/CatalogService.php
+++ b/src/Catalog/CatalogService.php
@@ -194,7 +194,7 @@ final class CatalogService extends AbstractService
                 $values = $attribute->getValues();
                 $brand = reset($values);
 
-                return new ProductAttributeValue($brand);
+                return $brand;
             }
         }
 

--- a/src/Catalog/SearchProductAttribute.php
+++ b/src/Catalog/SearchProductAttribute.php
@@ -15,7 +15,7 @@ final class SearchProductAttribute
     private $name;
     /** @var string */
     private $slug;
-    /** @var array */
+    /** @var ProductAttributeValue[] */
     private $values;
     /** @var AttributeType */
     private $type;
@@ -28,7 +28,9 @@ final class SearchProductAttribute
         $this->id = $data['attribute']['id'];
         $this->name = $data['attribute']['name'];
         $this->slug = $data['attribute']['slug'] ?? '';
-        $this->values = $data['values'] ?? []; // @TODO : use ProductAttributeValue[]
+        $this->values = array_map(static function (array $valueData): ProductAttributeValue {
+            return new ProductAttributeValue($valueData);
+        }, $data['values'] ?? []);
         $this->type = AttributeType::createFromLegacyMapping($data['attribute']['type']);
     }
 
@@ -47,6 +49,9 @@ final class SearchProductAttribute
         return $this->slug;
     }
 
+    /**
+     * @return ProductAttributeValue[]
+     */
     public function getValues(): array
     {
         return $this->values;

--- a/tests/Catalog/CatalogServiceTest.php
+++ b/tests/Catalog/CatalogServiceTest.php
@@ -335,57 +335,57 @@ final class CatalogServiceTest extends ApiTestCase
         // Couleur
         $this->assertSame('Couleur', $attributesMap[1]->getName());
         $this->assertSame('', $attributesMap[1]->getSlug());
-        $this->assertSame([
-            [
+        $this->assertEquals([
+            new ProductAttributeValue([
                 'id' => 2,
                 'attributeId' => 1,
                 'name' => 'Blanc',
                 'slug' => 'blanc',
                 'image' => null,
-            ],
-            [
+            ]),
+            new ProductAttributeValue([
                 'id' => 3,
                 'attributeId' => 1,
                 'name' => 'Rouge',
                 'slug' => 'rouge',
                 'image' => null,
-            ],
+            ]),
         ], $attributesMap[1]->getValues());
         $this->assertTrue(AttributeType::CHECKBOX_MULTIPLE()->equals($attributesMap[1]->getType()));
 
         // Free attributes
-        $this->assertSame([
-            [
+        $this->assertEquals([
+            new ProductAttributeValue([
                 'id' => null,
                 'attributeId' => null,
                 'name' => 'valeur simple du free attribute #12M%M_°09£*/.?',
                 'slug' => '',
                 'image' => null,
-            ],
+            ]),
         ], $freeAttributesMap['Free attribute simple']->getValues());
 
-        $this->assertSame([
-            [
+        $this->assertEquals([
+            new ProductAttributeValue([
                 'id' => null,
                 'attributeId' => null,
                 'name' => 'réponse - 1 #',
                 'slug' => '',
                 'image' => null,
-            ],
-            [
+            ]),
+            new ProductAttributeValue([
                 'id' => null,
                 'attributeId' => null,
                 'name' => 'réponse - 2 @',
                 'slug' => '',
                 'image' => null,
-            ],
-            [
+            ]),
+            new ProductAttributeValue([
                 'id' => null,
                 'attributeId' => null,
                 'name' => '4985',
                 'slug' => '',
                 'image' => null,
-            ],
+            ]),
         ], $freeAttributesMap['Free attribute multiple']->getValues());
 
         $brand = $catalogService->getBrand($product);

--- a/tests/Catalog/SearchProductAttributeTest.php
+++ b/tests/Catalog/SearchProductAttributeTest.php
@@ -9,6 +9,7 @@ namespace Wizaplace\SDK\Tests\Catalog;
 
 use PHPUnit\Framework\TestCase;
 use Wizaplace\SDK\Catalog\AttributeType;
+use Wizaplace\SDK\Catalog\ProductAttributeValue;
 use Wizaplace\SDK\Catalog\SearchProductAttribute;
 
 final class SearchProductAttributeTest extends TestCase
@@ -43,8 +44,8 @@ JSON;
         $this->assertSame('', $attribute->getSlug()); // @FIXME @TODO : the API does not give us this data. It should be added to the API, or removed from the SDK
         $this->assertTrue(AttributeType::CHECKBOX_MULTIPLE()->equals($attribute->getType()));
         $this->assertSame('Couleur test', $attribute->getName());
-        $this->assertSame([
-            [
+        $this->assertEquals([
+            new ProductAttributeValue([
                 'id' => 64,
                 'attributeId' => 52,
                 'name' => 'blue',
@@ -52,7 +53,7 @@ JSON;
                 'image' => [
                     'id' => 708,
                 ],
-            ],
+            ]),
         ], $attribute->getValues());
     }
 }


### PR DESCRIPTION
Fix #198

## Checklist

- [x] Changelog updated
