### PR TITLE
Change all URLs getter to return an UriInterface instead of a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ### BREAKING CHANGES
 
 - `\Wizaplace\SDK\Order\OrderReturn::getStatus` now returns an `\Wizaplace\SDK\Order\OrderReturnStatus` instead of a string
+- `\Wizaplace\SDK\Basket\PaymentInformation::getRedirectUrl` now returns a nullable `\Psr\Http\Message\UriInterface` instead of a `string`
+- `\Wizaplace\SDK\Company\Company::getUrl` now returns a nullable `\Psr\Http\Message\UriInterface` instead of a `string`
+- `\Wizaplace\SDK\Catalog\ProductVideo::getThumbnailUrl` now returns an `\Psr\Http\Message\UriInterface` instead of a `string`
+- `\Wizaplace\SDK\Catalog\ProductVideo::getVideoUrl` now returns an `\Psr\Http\Message\UriInterface` instead of a `string`
+- `\Wizaplace\SDK\Image\ImageService::getImageLink` now returns an `\Psr\Http\Message\UriInterface` instead of a `string`
 
 ### New features
 

--- a/src/Basket/PaymentInformation.php
+++ b/src/Basket/PaymentInformation.php
@@ -7,11 +7,14 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Basket;
 
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
 final class PaymentInformation
 {
     /** @var array */
     private $orders;
-    /** @var string */
+    /** @var null|UriInterface */
     private $redirectUrl;
     /** @var string */
     private $html;
@@ -22,7 +25,7 @@ final class PaymentInformation
     public function __construct(array $data)
     {
         $this->orders = $data['orders'];
-        $this->redirectUrl = $data['redirectUrl'] ?? '';
+        $this->redirectUrl = empty($data['redirectUrl']) ? null : new Uri($this->redirectUrl);
         $this->html = $data['html'] ?? '';
     }
 
@@ -31,7 +34,7 @@ final class PaymentInformation
         return $this->orders;
     }
 
-    public function getRedirectUrl(): string
+    public function getRedirectUrl(): ?UriInterface
     {
         return $this->redirectUrl;
     }

--- a/src/Basket/PaymentInformation.php
+++ b/src/Basket/PaymentInformation.php
@@ -25,7 +25,7 @@ final class PaymentInformation
     public function __construct(array $data)
     {
         $this->orders = $data['orders'];
-        $this->redirectUrl = empty($data['redirectUrl']) ? null : new Uri($this->redirectUrl);
+        $this->redirectUrl = !isset($data['redirectUrl']) || $data['redirectUrl'] === '' ? null : new Uri($this->redirectUrl);
         $this->html = $data['html'] ?? '';
     }
 

--- a/src/Catalog/DeclinationSummary.php
+++ b/src/Catalog/DeclinationSummary.php
@@ -75,7 +75,7 @@ final class DeclinationSummary
         $this->vat = $data['prices']['vat'];
         $this->crossedOutPrice = $data['crossedOutPrice'] ?? null;
         $this->amount = $data['amount'];
-        $this->affiliateLink = empty($data['affiliateLink']) ? null : new Uri($data['affiliateLink']);
+        $this->affiliateLink = $data['affiliateLink'] === '' ? null : new Uri($data['affiliateLink']);
         $this->options = array_map(static function (array $data): DeclinationOption {
             return new DeclinationOption($data);
         }, $data['options']);

--- a/src/Catalog/DeclinationSummary.php
+++ b/src/Catalog/DeclinationSummary.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Catalog;
 
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
 use Wizaplace\SDK\Image\Image;
 
 final class DeclinationSummary
@@ -41,7 +43,7 @@ final class DeclinationSummary
     /** @var int */
     private $amount;
 
-    /** @var string */
+    /** @var null|UriInterface */
     private $affiliateLink;
 
     /** @var DeclinationOption[] */
@@ -73,7 +75,7 @@ final class DeclinationSummary
         $this->vat = $data['prices']['vat'];
         $this->crossedOutPrice = $data['crossedOutPrice'] ?? null;
         $this->amount = $data['amount'];
-        $this->affiliateLink = $data['affiliateLink'];
+        $this->affiliateLink = empty($data['affiliateLink']) ? null : new Uri($data['affiliateLink']);
         $this->options = array_map(static function (array $data): DeclinationOption {
             return new DeclinationOption($data);
         }, $data['options']);
@@ -131,7 +133,7 @@ final class DeclinationSummary
         return $this->amount;
     }
 
-    public function getAffiliateLink(): string
+    public function getAffiliateLink(): ?UriInterface
     {
         return $this->affiliateLink;
     }

--- a/src/Catalog/ProductVideo.php
+++ b/src/Catalog/ProductVideo.php
@@ -7,12 +7,15 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Catalog;
 
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
 final class ProductVideo
 {
-    /** @var string */
+    /** @var UriInterface */
     private $thumbnailUrl;
 
-    /** @var string */
+    /** @var UriInterface */
     private $videoUrl;
 
     /**
@@ -20,16 +23,16 @@ final class ProductVideo
      */
     public function __construct(array $data)
     {
-        $this->thumbnailUrl = $data['thumbnailUrl'];
-        $this->videoUrl = $data['videoUrl'];
+        $this->thumbnailUrl = new Uri($data['thumbnailUrl']);
+        $this->videoUrl = new Uri($data['videoUrl']);
     }
 
-    public function getThumbnailUrl(): string
+    public function getThumbnailUrl(): UriInterface
     {
         return $this->thumbnailUrl;
     }
 
-    public function getVideoUrl(): string
+    public function getVideoUrl(): UriInterface
     {
         return $this->videoUrl;
     }

--- a/src/Company/Company.php
+++ b/src/Company/Company.php
@@ -7,6 +7,9 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Company;
 
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
 final class Company
 {
     /** @var int */
@@ -39,7 +42,7 @@ final class Company
     /** @var string */
     private $fax;
 
-    /** @var string */
+    /** @var null|UriInterface */
     private $url;
 
     /** @var string */
@@ -75,7 +78,7 @@ final class Company
         $this->country = (string) $data['country'];
         $this->phoneNumber = (string) $data['phoneNumber'];
         $this->fax = (string) $data['fax'];
-        $this->url = (string) $data['url'];
+        $this->url = empty($data['url']) ? null : new Uri($data['url']);
         $this->legalStatus = (string) $data['legalStatus'];
         $this->siretNumber = (string) $data['siretNumber'];
         $this->vatNumber = (string) $data['vatNumber'];
@@ -134,7 +137,7 @@ final class Company
         return $this->fax;
     }
 
-    public function getUrl(): string
+    public function getUrl(): ?UriInterface
     {
         return $this->url;
     }

--- a/src/Company/Company.php
+++ b/src/Company/Company.php
@@ -78,7 +78,7 @@ final class Company
         $this->country = (string) $data['country'];
         $this->phoneNumber = (string) $data['phoneNumber'];
         $this->fax = (string) $data['fax'];
-        $this->url = empty($data['url']) ? null : new Uri($data['url']);
+        $this->url = $data['url'] === '' ? null : new Uri($data['url']);
         $this->legalStatus = (string) $data['legalStatus'];
         $this->siretNumber = (string) $data['siretNumber'];
         $this->vatNumber = (string) $data['vatNumber'];

--- a/src/Image/ImageService.php
+++ b/src/Image/ImageService.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Image;
 
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
 use Wizaplace\SDK\AbstractService;
 
 final class ImageService extends AbstractService
@@ -21,14 +23,14 @@ final class ImageService extends AbstractService
      * @param int|null $width You can optionally constraint the max width of the image.
      * @param int|null $height You can optionally constraint the max height of the image.
      *
-     * @return string Image URL
+     * @return UriInterface Image URL
      */
-    public function getImageLink(int $imageId, int $width = null, int $height = null): string
+    public function getImageLink(int $imageId, int $width = null, int $height = null): UriInterface
     {
         $query = http_build_query(array_filter(['w' => $width, 'h' => $height]));
 
         $apiBaseUrl = rtrim((string) $this->client->getBaseUri(), '/');
 
-        return "{$apiBaseUrl}/image/${imageId}?${query}";
+        return new Uri("{$apiBaseUrl}/image/${imageId}?${query}");
     }
 }

--- a/tests/Basket/BasketServiceTest.php
+++ b/tests/Basket/BasketServiceTest.php
@@ -83,7 +83,7 @@ final class BasketServiceTest extends ApiTestCase
 
         // @TODO : check that the two following values are normal
         $this->assertSame('', $paymentInformation->getHtml());
-        $this->assertSame('', $paymentInformation->getRedirectUrl());
+        $this->assertNull($paymentInformation->getRedirectUrl());
 
         $orders = $paymentInformation->getOrders();
         $this->assertCount(1, $orders);

--- a/tests/Catalog/CatalogServiceTest.php
+++ b/tests/Catalog/CatalogServiceTest.php
@@ -1279,8 +1279,8 @@ final class CatalogServiceTest extends ApiTestCase
     {
         $video = $this->buildCatalogService()->getProductById('3')->getVideo();
         $this->assertInstanceOf(ProductVideo::class, $video);
-        $this->assertSame('//s3-eu-west-1.amazonaws.com/wizachatest/videos/414375b2-61cb-4260-b82b-4a2636cb5673/480-00001.png', $video->getThumbnailUrl());
-        $this->assertSame('//s3-eu-west-1.amazonaws.com/wizachatest/videos/414375b2-61cb-4260-b82b-4a2636cb5673/480.mp4', $video->getVideoUrl());
+        $this->assertSame('//s3-eu-west-1.amazonaws.com/wizachatest/videos/414375b2-61cb-4260-b82b-4a2636cb5673/480-00001.png', (string) $video->getThumbnailUrl());
+        $this->assertSame('//s3-eu-west-1.amazonaws.com/wizachatest/videos/414375b2-61cb-4260-b82b-4a2636cb5673/480.mp4', (string) $video->getVideoUrl());
     }
 
     public function testReportingProduct()

--- a/tests/Catalog/DeclinationSummaryTest.php
+++ b/tests/Catalog/DeclinationSummaryTest.php
@@ -72,7 +72,7 @@ final class DeclinationSummaryTest extends TestCase
         $this->assertSame(12.5, $favorite->getVat());
         $this->assertSame(99.99, $favorite->getCrossedOutPrice());
         $this->assertSame(24, $favorite->getAmount());
-        $this->assertSame('http://example.com', $favorite->getAffiliateLink());
+        $this->assertSame('http://example.com', (string) $favorite->getAffiliateLink());
         $this->assertCount(1, $favorite->getOptions());
         $this->assertInstanceOf(DeclinationOption::class, $favorite->getOptions()[0]);
         $this->assertSame(1, $favorite->getOptions()[0]->getId());

--- a/tests/Image/ImageServiceTest.php
+++ b/tests/Image/ImageServiceTest.php
@@ -14,17 +14,17 @@ final class ImageServiceTest extends ApiTestCase
 {
     public function testGetImageLink()
     {
-        $this->assertSame('http://wizaplace.loc/api/v1/image/1?', $this->buildImageService()->getImageLink(1));
+        $this->assertSame('http://wizaplace.loc/api/v1/image/1', (string) $this->buildImageService()->getImageLink(1));
     }
 
     public function testGetImageLinkWithWidth()
     {
-        $this->assertSame('http://wizaplace.loc/api/v1/image/1?w=42', $this->buildImageService()->getImageLink(1, 42));
+        $this->assertSame('http://wizaplace.loc/api/v1/image/1?w=42', (string) $this->buildImageService()->getImageLink(1, 42));
     }
 
     public function testGetImageLinkWithWidthAndHeight()
     {
-        $this->assertSame('http://wizaplace.loc/api/v1/image/1?w=42&h=36', $this->buildImageService()->getImageLink(1, 42, 36));
+        $this->assertSame('http://wizaplace.loc/api/v1/image/1?w=42&h=36', (string) $this->buildImageService()->getImageLink(1, 42, 36));
     }
 
     private function buildImageService(): ImageService


### PR DESCRIPTION
Before this PR, we had `UriInterface` in some places, and `string` in some others (with the `string` sometimes empty).

After this PR, it's all `UriInterface` or `?UriInterface`

It should be transparent to most users, as `UriInterface` can be casted to string.

## Checklist

- [x] Changelog updated
