### PR TITLE
PaymentInformation::getOrders now returns an array of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed `\Wizaplace\SDK\Catalog\ProductSummary::getCategorySlugs`
 - Removed `\Wizaplace\SDK\Catalog\Product::getCategorySlugs`
 - `\Wizaplace\SDK\Catalog\ProductSummary::getConditions` now returns an array of the enum `\Wizaplace\SDK\Catalog\Condition` instead of undocumented strings
+- `\Wizaplace\SDK\Basket\PaymentInformation::getOrders` now returns an array of `\Wizaplace\SDK\Basket\BasketOrder` instead of an array of undocumented associative arrays
 
 ### New features
 

--- a/src/Basket/BasketOrder.php
+++ b/src/Basket/BasketOrder.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+declare(strict_types=1);
+
+namespace Wizaplace\SDK\Basket;
+
+final class BasketOrder
+{
+    /** @var int */
+    private $id;
+
+    /**
+     * @internal
+     */
+    public function __construct(array $data)
+    {
+        $this->id = $data['id'];
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/src/Basket/PaymentInformation.php
+++ b/src/Basket/PaymentInformation.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\UriInterface;
 
 final class PaymentInformation
 {
-    /** @var array */
+    /** @var BasketOrder[] */
     private $orders;
     /** @var null|UriInterface */
     private $redirectUrl;
@@ -24,11 +24,16 @@ final class PaymentInformation
      */
     public function __construct(array $data)
     {
-        $this->orders = $data['orders'];
+        $this->orders = array_map(static function (array $orderData): BasketOrder {
+            return new BasketOrder($orderData);
+        }, $data['orders']);
         $this->redirectUrl = !isset($data['redirectUrl']) || $data['redirectUrl'] === '' ? null : new Uri($this->redirectUrl);
         $this->html = $data['html'] ?? '';
     }
 
+    /**
+     * @return BasketOrder[]
+     */
     public function getOrders(): array
     {
         return $this->orders;

--- a/tests/Basket/BasketServiceTest.php
+++ b/tests/Basket/BasketServiceTest.php
@@ -88,8 +88,8 @@ final class BasketServiceTest extends ApiTestCase
         $orders = $paymentInformation->getOrders();
         $this->assertCount(1, $orders);
 
-        $order = $orderService->getOrder($orders[0]['id']);
-        $this->assertSame($orders[0]['id'], $order->getId());
+        $order = $orderService->getOrder($orders[0]->getId());
+        $this->assertSame($orders[0]->getId(), $order->getId());
         $this->assertSame(3, $order->getCompanyId());
         $this->assertSame('Colissmo', $order->getShippingName());
         $this->assertEquals(OrderStatus::STANDBY_BILLING(), $order->getStatus());


### PR DESCRIPTION
Closes #204 

## Checklist

- [x] Changelog updated
