### PR TITLE
DeclinationSummary::getProductId` now returns a `string` instead of an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `\Wizaplace\SDK\Catalog\ProductAttachment` class is now final
 - `\Wizaplace\SDK\Catalog\ProductAttributeValue` class is now final
 - `\Wizaplace\SDK\Catalog\Facet` has moved to `\Wizaplace\SDK\Catalog\Facet\Facet` and is now an abstract class with two subclasses: `\Wizaplace\SDK\Catalog\Facet\ListFacet` and `\Wizaplace\SDK\Catalog\Facet\NumericFacet`. A few methods have changed in the process
+- `\Wizaplace\SDK\Catalog\DeclinationSummary::getProductId` now returns a `string` instead of an `int`
 
 ### New features
 

--- a/src/Catalog/DeclinationSummary.php
+++ b/src/Catalog/DeclinationSummary.php
@@ -16,7 +16,7 @@ final class DeclinationSummary
     /** @var string */
     private $id;
 
-    /** @var int */
+    /** @var string */
     private $productId;
 
     /** @var string */
@@ -67,7 +67,7 @@ final class DeclinationSummary
     public function __construct(array $data)
     {
         $this->id = $data['id'];
-        $this->productId = $data['productId'];
+        $this->productId = (string) $data['productId'];
         $this->name = $data['name'];
         $this->code = $data['code'];
         $this->priceWithTaxes = $data['prices']['priceWithTaxes'];
@@ -93,7 +93,7 @@ final class DeclinationSummary
         return $this->id;
     }
 
-    public function getProductId(): int
+    public function getProductId(): string
     {
         return $this->productId;
     }

--- a/tests/Catalog/DeclinationSummaryTest.php
+++ b/tests/Catalog/DeclinationSummaryTest.php
@@ -64,7 +64,7 @@ final class DeclinationSummaryTest extends TestCase
         ]);
 
         $this->assertSame('42_1_2', $favorite->getId());
-        $this->assertSame(42, $favorite->getProductId());
+        $this->assertSame('42', $favorite->getProductId());
         $this->assertSame('Very comfortable chair', $favorite->getName());
         $this->assertSame('4006381333933', $favorite->getCode());
         $this->assertSame(79.99, $favorite->getPriceWithTaxes());

--- a/tests/Favorite/FavoriteServiceTest.php
+++ b/tests/Favorite/FavoriteServiceTest.php
@@ -72,10 +72,10 @@ final class FavoriteServiceTest extends ApiTestCase
         $this->assertTrue(is_array($favorites));
         $this->assertCount(2, $favorites);
         $this->assertInstanceOf(DeclinationSummary::class, reset($favorites));
-        $this->assertSame(1, reset($favorites)->getProductId());
+        $this->assertSame('1', reset($favorites)->getProductId());
         $this->assertTrue(current($favorites)->isAvailable());
         next($favorites);
-        $this->assertSame(2, current($favorites)->getProductId());
+        $this->assertSame('2', current($favorites)->getProductId());
         $this->assertTrue(current($favorites)->isAvailable());
     }
 


### PR DESCRIPTION
Question de cohérence, tous nos autres productId sont des strings

## Checklist

- [x] Changelog updated
