### PR TITLE
Use safe casts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "guzzlehttp/guzzle": "^6.2",
         "guzzlehttp/psr7": "^1.4",
         "myclabs/php-enum": "^1.5",
-        "jean85/pretty-package-versions": "^1.0"
+        "jean85/pretty-package-versions": "^1.0",
+        "theodorejb/polycast": "^1.0"
     },
     "autoload": {
         "psr-4": {"Wizaplace\\SDK\\": "src/"}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c7d795a07d72fced299efa718006e73",
+    "content-hash": "7413a9ffafdf5617acafc575b2a821cb",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -372,6 +372,43 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "theodorejb/polycast",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theodorejb/PolyCast.git",
+                "reference": "68ae87e42ead5c1a59ae4e03446607f592cefea3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theodorejb/PolyCast/zipball/68ae87e42ead5c1a59ae4e03446607f592cefea3",
+                "reference": "68ae87e42ead5c1a59ae4e03446607f592cefea3",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/PolyCast.php",
+                    "lib/CastException.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Theodore Brown",
+                    "email": "theodorejb@outlook.com"
+                }
+            ],
+            "description": "Safely cast values to int, float, or string",
+            "time": "2015-10-25T19:36:42+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Basket/BasketService.php
+++ b/src/Basket/BasketService.php
@@ -17,6 +17,7 @@ use Wizaplace\SDK\Basket\Exception\CouponNotInTheBasket;
 use Wizaplace\SDK\Catalog\DeclinationId;
 use Wizaplace\SDK\Exception\NotFound;
 use Wizaplace\SDK\Exception\SomeParametersAreInvalid;
+use function theodorejb\polycast\to_string;
 
 /**
  * This service helps creating orders through a basket.
@@ -60,7 +61,7 @@ final class BasketService extends AbstractService
      */
     public function create(): string
     {
-        return (string) $this->client->post("basket");
+        return to_string($this->client->post("basket"));
     }
 
     /**
@@ -82,7 +83,7 @@ final class BasketService extends AbstractService
         try {
             $responseData = $this->client->post("basket/{$basketId}/add", [
                 RequestOptions::FORM_PARAMS => [
-                    'declinationId' => (string) $declinationId,
+                    'declinationId' => to_string($declinationId),
                     'quantity' => $quantity,
                 ],
             ]);
@@ -149,7 +150,7 @@ final class BasketService extends AbstractService
         try {
             $this->client->post("basket/{$basketId}/remove", [
                 RequestOptions::FORM_PARAMS => [
-                    'declinationId' => (string) $declinationId,
+                    'declinationId' => to_string($declinationId),
                 ],
             ]);
         } catch (ClientException $ex) {
@@ -199,7 +200,7 @@ final class BasketService extends AbstractService
         try {
             $responseData = $this->client->post("basket/{$basketId}/modify", [
                 RequestOptions::FORM_PARAMS => [
-                    'declinationId' => (string) $declinationId,
+                    'declinationId' => to_string($declinationId),
                     'quantity' => $quantity,
                 ],
             ]);

--- a/src/Basket/BasketShippingGroup.php
+++ b/src/Basket/BasketShippingGroup.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Basket;
 
+use function theodorejb\polycast\to_int;
+
 final class BasketShippingGroup
 {
     /** @var int */
@@ -23,7 +25,7 @@ final class BasketShippingGroup
      */
     public function __construct(array $data)
     {
-        $this->id = (int) $data['id'];
+        $this->id = to_int($data['id']);
 
         $this->items = array_map(static function (array $item) : BasketItem {
             return new BasketItem($item);

--- a/src/Basket/DeclinationOption.php
+++ b/src/Basket/DeclinationOption.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Basket;
 
+use function theodorejb\polycast\to_string;
+
 final class DeclinationOption
 {
     /** @var int */
@@ -27,9 +29,9 @@ final class DeclinationOption
     public function __construct(array $data)
     {
         $this->optionId = $data['optionId'];
-        $this->optionName = (string) $data['optionName'];
+        $this->optionName = to_string($data['optionName']);
         $this->variantId = $data['variantId'];
-        $this->variantName = (string) $data['variantName'];
+        $this->variantName = to_string($data['variantName']);
     }
 
     public function getOptionId(): int

--- a/src/Basket/Payment.php
+++ b/src/Basket/Payment.php
@@ -8,6 +8,8 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Basket;
 
 use Wizaplace\SDK\Image\Image;
+use function theodorejb\polycast\to_int;
+use function theodorejb\polycast\to_string;
 
 final class Payment
 {
@@ -27,10 +29,10 @@ final class Payment
      */
     public function __construct(array $data)
     {
-        $this->id = (int) $data['id'];
-        $this->name = (string) $data['name'];
-        $this->description = (string) $data['description'];
-        $this->position = (int) $data['position'];
+        $this->id = to_int($data['id']);
+        $this->name = to_string($data['name']);
+        $this->description = to_string($data['description']);
+        $this->position = to_int($data['position']);
         if (isset($data['image'])) {
             $this->image = new Image($data['image']);
         }

--- a/src/Basket/ProductComment.php
+++ b/src/Basket/ProductComment.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Wizaplace\SDK\Basket;
 
 use Wizaplace\SDK\Catalog\DeclinationId;
+use function theodorejb\polycast\to_string;
 
 final class ProductComment extends Comment
 {
@@ -34,7 +35,7 @@ final class ProductComment extends Comment
     public function toArray(): array
     {
         return [
-            'declinationId' => (string) $this->declinationId,
+            'declinationId' => to_string($this->declinationId),
             'comment' => $this->comment,
         ];
     }

--- a/src/Catalog/CatalogService.php
+++ b/src/Catalog/CatalogService.php
@@ -12,6 +12,7 @@ use GuzzleHttp\RequestOptions;
 use Wizaplace\SDK\AbstractService;
 use Wizaplace\SDK\Exception\NotFound;
 use Wizaplace\SDK\Exception\SomeParametersAreInvalid;
+use function theodorejb\polycast\to_string;
 
 final class CatalogService extends AbstractService
 {
@@ -161,7 +162,7 @@ final class CatalogService extends AbstractService
                 case 404:
                     throw new NotFound("Product #{$report->getProductId()} not found", $e);
                 case 400:
-                    throw new SomeParametersAreInvalid((string) $e->getResponse()->getBody(), 400, $e);
+                    throw new SomeParametersAreInvalid(to_string($e->getResponse()->getBody()), 400, $e);
             }
             throw $e;
         }

--- a/src/Catalog/CompanyDetail.php
+++ b/src/Catalog/CompanyDetail.php
@@ -8,6 +8,8 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Catalog;
 
 use Wizaplace\SDK\Image\Image;
+use function theodorejb\polycast\to_int;
+use function theodorejb\polycast\to_string;
 
 final class CompanyDetail
 {
@@ -49,13 +51,13 @@ final class CompanyDetail
      */
     public function __construct(array $data)
     {
-        $this->id = (int) $data['id'];
-        $this->name = (string) $data['name'];
-        $this->description = (string) $data['description'];
-        $this->address = (string) $data['address'];
-        $this->phoneNumber = (string) $data['phoneNumber'];
+        $this->id = to_int($data['id']);
+        $this->name = to_string($data['name']);
+        $this->description = to_string($data['description']);
+        $this->address = to_string($data['address']);
+        $this->phoneNumber = to_string($data['phoneNumber']);
         $this->professional = (bool) $data['professional'];
-        $this->slug = (string) $data['slug'];
+        $this->slug = to_string($data['slug']);
         $this->image = ($data['image'] !== null) ? new Image($data['image']) : null;
         if ($data['location'] !== null) {
             $this->location = new Location($data['location']['latitude'], $data['location']['longitude']);
@@ -63,7 +65,7 @@ final class CompanyDetail
             $this->location = null;
         }
         $this->averageRating = $data['averageRating'];
-        $this->terms = (string) $data['terms'];
+        $this->terms = to_string($data['terms']);
     }
 
     public function getId(): int

--- a/src/Catalog/DeclinationSummary.php
+++ b/src/Catalog/DeclinationSummary.php
@@ -10,6 +10,7 @@ namespace Wizaplace\SDK\Catalog;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
 use Wizaplace\SDK\Image\Image;
+use function theodorejb\polycast\to_string;
 
 final class DeclinationSummary
 {
@@ -67,7 +68,7 @@ final class DeclinationSummary
     public function __construct(array $data)
     {
         $this->id = new DeclinationId($data['id']);
-        $this->productId = (string) $data['productId'];
+        $this->productId = to_string($data['productId']);
         $this->name = $data['name'];
         $this->code = $data['code'];
         $this->priceWithTaxes = $data['prices']['priceWithTaxes'];

--- a/src/Catalog/Facet/Facet.php
+++ b/src/Catalog/Facet/Facet.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Catalog\Facet;
 
+use function theodorejb\polycast\to_string;
+
 abstract class Facet
 {
     /** @var string */
@@ -19,7 +21,7 @@ abstract class Facet
      */
     public function __construct(array $data)
     {
-        $this->name = (string) $data['name']; // string cast is necessary because the API sometimes sends IDs as integers
+        $this->name = to_string($data['name']); // string cast is necessary because the API sometimes sends IDs as integers
         $this->label = $data['label'];
     }
 

--- a/src/Catalog/Product.php
+++ b/src/Catalog/Product.php
@@ -9,6 +9,8 @@ namespace Wizaplace\SDK\Catalog;
 
 use Psr\Http\Message\UriInterface;
 use Wizaplace\SDK\Exception\NotFound;
+use function theodorejb\polycast\to_float;
+use function theodorejb\polycast\to_string;
 
 final class Product
 {
@@ -83,16 +85,16 @@ final class Product
      */
     public function __construct(array $data, UriInterface $apiBaseUrl)
     {
-        $this->id = (string) $data['id'];
+        $this->id = to_string($data['id']);
         $this->code = $data['code'];
         $this->supplierReference = $data['supplierReference'];
         $this->name = $data['name'];
         $this->url = $data['url'];
         $this->shortDescription = $data['shortDescription'];
         $this->description = $data['description'];
-        $this->slug = (string) $data['slug'];
-        $this->minPrice = (float) $data['minPrice'];
-        $this->greenTax = (float) $data['greenTax'];
+        $this->slug = to_string($data['slug']);
+        $this->minPrice = to_float($data['minPrice']);
+        $this->greenTax = to_float($data['greenTax']);
         $this->attributes = array_map(static function (array $attributeData) : ProductAttribute {
             return new ProductAttribute($attributeData);
         }, $data['attributes']);

--- a/src/Catalog/ProductAttribute.php
+++ b/src/Catalog/ProductAttribute.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Catalog;
 
+use function theodorejb\polycast\to_string;
+
 final class ProductAttribute
 {
     /** @var int|null */
@@ -30,7 +32,7 @@ final class ProductAttribute
     public function __construct(array $data)
     {
         $this->id = $data['id'];
-        $this->name = (string) $data['name'];
+        $this->name = to_string($data['name']);
         $this->value = $data['value'];
         $this->valueIds = $data['valueIds'];
         $this->imageUrls = $data['imageUrls'] ?? [];

--- a/src/Catalog/ProductSummary.php
+++ b/src/Catalog/ProductSummary.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Catalog;
 
 use Wizaplace\SDK\Image\Image;
+use function theodorejb\polycast\to_string;
 
 final class ProductSummary
 {
@@ -59,14 +60,14 @@ final class ProductSummary
      */
     public function __construct(array $data)
     {
-        $this->productId = (string) $data['productId'];
-        $this->name = (string) $data['name'];
-        $this->subtitle = (string) $data['subtitle'];
-        $this->shortDescription = (string) $data['shortDescription'];
+        $this->productId = to_string($data['productId']);
+        $this->name = to_string($data['name']);
+        $this->subtitle = to_string($data['subtitle']);
+        $this->shortDescription = to_string($data['shortDescription']);
         $this->minimumPrice = $data['minimumPrice'];
         $this->crossedOutPrice = $data['crossedOutPrice'];
         $this->isAvailable = $data['isAvailable'];
-        $this->url = (string) $data['url'];
+        $this->url = to_string($data['url']);
         $this->createdAt = new \DateTimeImmutable("@{$data['createdAt']}");
         $this->updatedAt = new \DateTimeImmutable("@{$data['updatedAt']}");
         $this->declinationCount = $data['declinationCount'];
@@ -82,7 +83,7 @@ final class ProductSummary
         $this->categoryPath = array_map(static function (array $categoryPath) : SearchCategoryPath {
             return new SearchCategoryPath($categoryPath);
         }, $data['categoryPath']);
-        $this->slug = (string) $data['slug'];
+        $this->slug = to_string($data['slug']);
         $this->companies = array_map(static function (array $companyData) : CompanySummary {
             return new CompanySummary($companyData);
         }, $data['companies'] ?? []);

--- a/src/Cms/BannerService.php
+++ b/src/Cms/BannerService.php
@@ -9,6 +9,7 @@ namespace Wizaplace\SDK\Cms;
 
 use GuzzleHttp\Psr7\Uri;
 use Wizaplace\SDK\AbstractService;
+use function theodorejb\polycast\to_string;
 
 final class BannerService extends AbstractService
 {
@@ -47,7 +48,7 @@ final class BannerService extends AbstractService
     {
         $banners = [];
         foreach ($results as $result) {
-            $banner = new Banner(new Uri((string) $result['link']), $result['shouldOpenInNewWindow'], $result['image']['id']);
+            $banner = new Banner(new Uri(to_string($result['link'])), $result['shouldOpenInNewWindow'], $result['image']['id']);
             $banners[] = $banner;
         }
 

--- a/src/Cms/CmsService.php
+++ b/src/Cms/CmsService.php
@@ -9,6 +9,8 @@ namespace Wizaplace\SDK\Cms;
 
 use GuzzleHttp\Psr7\Uri;
 use Wizaplace\SDK\AbstractService;
+use function theodorejb\polycast\to_int;
+use function theodorejb\polycast\to_string;
 
 final class CmsService extends AbstractService
 {
@@ -43,11 +45,11 @@ final class CmsService extends AbstractService
     {
         $items = array_map([$this, 'convertArrayToMenuItem'], $menuData['items']);
 
-        return new Menu((int) $menuData['id'], (string) $menuData['name'], $items);
+        return new Menu(to_int($menuData['id']), to_string($menuData['name']), $items);
     }
 
     private function convertArrayToMenuItem(array $menuItem): MenuItem
     {
-        return new MenuItem((string) $menuItem['name'], (int) $menuItem['position'], new Uri((string) $menuItem['url']));
+        return new MenuItem(to_string($menuItem['name']), to_int($menuItem['position']), new Uri(to_string($menuItem['url'])));
     }
 }

--- a/src/Company/Company.php
+++ b/src/Company/Company.php
@@ -9,6 +9,8 @@ namespace Wizaplace\SDK\Company;
 
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
+use function theodorejb\polycast\to_int;
+use function theodorejb\polycast\to_string;
 
 final class Company
 {
@@ -68,23 +70,23 @@ final class Company
      */
     public function __construct(array $data)
     {
-        $this->id = (int) $data['id'];
-        $this->name = (string) $data['name'];
-        $this->email = (string) $data['email'];
-        $this->description = (string) $data['description'];
-        $this->zipcode = (string) $data['zipcode'];
-        $this->address = (string) $data['address'];
-        $this->city = (string) $data['city'];
-        $this->country = (string) $data['country'];
-        $this->phoneNumber = (string) $data['phoneNumber'];
-        $this->fax = (string) $data['fax'];
+        $this->id = to_int($data['id']);
+        $this->name = to_string($data['name']);
+        $this->email = to_string($data['email']);
+        $this->description = to_string($data['description']);
+        $this->zipcode = to_string($data['zipcode']);
+        $this->address = to_string($data['address']);
+        $this->city = to_string($data['city']);
+        $this->country = to_string($data['country']);
+        $this->phoneNumber = to_string($data['phoneNumber']);
+        $this->fax = to_string($data['fax']);
         $this->url = $data['url'] === '' ? null : new Uri($data['url']);
-        $this->legalStatus = (string) $data['legalStatus'];
-        $this->siretNumber = (string) $data['siretNumber'];
-        $this->vatNumber = (string) $data['vatNumber'];
-        $this->capital = (string) $data['capital'];
-        $this->rcs = (string) $data['rcs'];
-        $this->slug = (string) $data['slug'];
+        $this->legalStatus = to_string($data['legalStatus']);
+        $this->siretNumber = to_string($data['siretNumber']);
+        $this->vatNumber = to_string($data['vatNumber']);
+        $this->capital = to_string($data['capital']);
+        $this->rcs = to_string($data['rcs']);
+        $this->slug = to_string($data['slug']);
     }
 
     public function getId(): int

--- a/src/Discussion/Discussion.php
+++ b/src/Discussion/Discussion.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Discussion;
 
+use function theodorejb\polycast\to_int;
+
 final class Discussion
 {
     /** @var int */
@@ -31,7 +33,7 @@ final class Discussion
     {
         $this->id = $data['id'];
         $this->recipient = $data['recipient'];
-        $this->productId = (int) $data['productId'];
+        $this->productId = to_int($data['productId']);
         $this->title = $data['title'];
         $this->unreadCount = $data['unreadCount'];
     }

--- a/src/Favorite/FavoriteService.php
+++ b/src/Favorite/FavoriteService.php
@@ -13,6 +13,7 @@ use Wizaplace\SDK\Catalog\DeclinationId;
 use Wizaplace\SDK\Catalog\DeclinationSummary;
 use Wizaplace\SDK\Favorite\Exception\CannotFavoriteDisabledOrInexistentDeclination;
 use Wizaplace\SDK\Favorite\Exception\FavoriteAlreadyExist;
+use function theodorejb\polycast\to_string;
 
 /**
  * This service helps managing the favorite products of a user.
@@ -48,7 +49,7 @@ final class FavoriteService extends AbstractService
         $isInFavorites = false;
         if ($results['count'] > 0) {
             foreach ($results['_embedded']['favorites'] as $result) {
-                if ($result === (string) $declinationId) {
+                if ($result === to_string($declinationId)) {
                     $isInFavorites = true;
                     break;
                 }

--- a/src/Image/ImageService.php
+++ b/src/Image/ImageService.php
@@ -10,6 +10,7 @@ namespace Wizaplace\SDK\Image;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
 use Wizaplace\SDK\AbstractService;
+use function theodorejb\polycast\to_string;
 
 final class ImageService extends AbstractService
 {
@@ -29,7 +30,7 @@ final class ImageService extends AbstractService
     {
         $query = http_build_query(array_filter(['w' => $width, 'h' => $height]));
 
-        $apiBaseUrl = rtrim((string) $this->client->getBaseUri(), '/');
+        $apiBaseUrl = rtrim(to_string($this->client->getBaseUri()), '/');
 
         return new Uri("{$apiBaseUrl}/image/${imageId}?${query}");
     }

--- a/src/Order/CreateOrderReturn.php
+++ b/src/Order/CreateOrderReturn.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Order;
 
 use Wizaplace\SDK\Catalog\DeclinationId;
+use function theodorejb\polycast\to_string;
 
 /**
  * @see \Wizaplace\SDK\Order\OrderService::createOrderReturn
@@ -39,7 +40,7 @@ final class CreateOrderReturn
     public function addItem(DeclinationId $declinationId, int $reason, int $amount): void
     {
         $this->items[] = [
-            'declinationId' => (string) $declinationId,
+            'declinationId' => to_string($declinationId),
             'reason' => $reason,
             'amount' => $amount,
         ];

--- a/src/Order/DeclinationOption.php
+++ b/src/Order/DeclinationOption.php
@@ -7,6 +7,8 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Order;
 
+use function theodorejb\polycast\to_string;
+
 final class DeclinationOption
 {
     /** @var int */
@@ -27,9 +29,9 @@ final class DeclinationOption
     public function __construct(array $data)
     {
         $this->optionId = $data['optionId'];
-        $this->optionName = (string) $data['optionName'];
+        $this->optionName = to_string($data['optionName']);
         $this->variantId = $data['variantId'];
-        $this->variantName = (string) $data['variantName'];
+        $this->variantName = to_string($data['variantName']);
     }
 
     public function getOptionId(): int

--- a/src/Order/ReturnItem.php
+++ b/src/Order/ReturnItem.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Order;
 
 use Wizaplace\SDK\Catalog\DeclinationId;
+use function theodorejb\polycast\to_string;
 
 final class ReturnItem
 {
@@ -27,8 +28,8 @@ final class ReturnItem
      */
     public function __construct(array $data)
     {
-        $this->declinationId = new DeclinationId((string) $data['declinationId']);
-        $this->productName = (string) $data['productName'];
+        $this->declinationId = new DeclinationId(to_string($data['declinationId']));
+        $this->productName = to_string($data['productName']);
         $this->price = $data['price'];
         $this->reason = $data['reason'];
         $this->amount = $data['amount'];

--- a/src/Seo/SeoService.php
+++ b/src/Seo/SeoService.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Seo;
 
 use Wizaplace\SDK\AbstractService;
+use function theodorejb\polycast\to_string;
 
 final class SeoService extends AbstractService
 {
@@ -34,7 +35,7 @@ final class SeoService extends AbstractService
             if (!isset($rawResults[$slug])) {
                 $results[$slug] = null;
             } else {
-                $results[$slug] = new SlugTarget(new SlugTargetType($rawResults[$slug]['type']), (string) $rawResults[$slug]['id']);
+                $results[$slug] = new SlugTarget(new SlugTargetType($rawResults[$slug]['type']), to_string($rawResults[$slug]['id']));
             }
         }
 

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -7,6 +7,9 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\User;
 
+use function theodorejb\polycast\to_int;
+use function theodorejb\polycast\to_string;
+
 final class User
 {
     private const BIRTHDAY_FORMAT = 'Y-m-d';
@@ -33,11 +36,11 @@ final class User
      */
     public function __construct(array $data)
     {
-        $this->id = (int) $data['id'];
-        $this->email = (string) $data['email'];
+        $this->id = to_int($data['id']);
+        $this->email = to_string($data['email']);
         $this->title = empty($data['title']) ? null : new UserTitle($data['title']);
-        $this->firstname = (string) $data['firstName'];
-        $this->lastname = (string) $data['lastName'];
+        $this->firstname = to_string($data['firstName']);
+        $this->lastname = to_string($data['lastName']);
         $this->birthday = empty($data['birthday']) ? null : \DateTimeImmutable::createFromFormat(self::BIRTHDAY_FORMAT, $data['birthday']);
         $this->billingAddress = isset($data['addresses']['billing']) ? new UserAddress($data['addresses']['billing']) : null;
         $this->shippingAddress = isset($data['addresses']['shipping']) ? new UserAddress($data['addresses']['shipping']) : null;

--- a/src/User/UserService.php
+++ b/src/User/UserService.php
@@ -14,6 +14,7 @@ use Wizaplace\SDK\AbstractService;
 use Wizaplace\SDK\Authentication\AuthenticationRequired;
 use Wizaplace\SDK\Exception\NotFound;
 use Wizaplace\SDK\Exception\SomeParametersAreInvalid;
+use function theodorejb\polycast\to_string;
 
 final class UserService extends AbstractService
 {
@@ -127,7 +128,7 @@ final class UserService extends AbstractService
             'email' => $email,
         ];
         if (!empty($recoverBaseUrl)) {
-            $data['recoverBaseUrl'] = (string) $recoverBaseUrl;
+            $data['recoverBaseUrl'] = to_string($recoverBaseUrl);
         }
 
         // On attend une 204 donc pas de retour


### PR DESCRIPTION
Le besoin est expliqué ici : https://github.com/wizaplace/wizaplace-php-sdk/pull/221#discussion_r152759869

Je copie-colle : 

-----

Je préfère minimiser les casts en int, car ils ne font aucune vérification de ce qu'on leur donne.

Plusieurs fois on s'est retrouvé avec des UUID qui une fois castés donnait 0... C'est tout aussi aberrant que empty().

En fait il me faut une fonction `/** @throws NotANumberException **/ parseInt(mixed $val): int` et là je serais tout à fait ok pour l'utiliser partout où on attend des int.