### PR TITLE
fix BasketService::getUserBasketId returning empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Bugfixes
 
+ - Fix `\Wizaplace\SDK\Basket\BasketService::getUserBasketId` which sometimes returned an empty string instead of `null`
+
 </details>
 
 ## 1.10.0

--- a/src/Basket/BasketService.php
+++ b/src/Basket/BasketService.php
@@ -119,7 +119,12 @@ final class BasketService extends AbstractService
 
         $response = $this->client->get("users/$userId/basket");
 
-        return $response['id'];
+        $id = $response['id'];
+        if ($id === '') {
+            $id = null;
+        }
+
+        return $id;
     }
 
     /**


### PR DESCRIPTION
## Checklist

- [x] Changelog updated
