### PR TITLE
Register user with full informations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### New features
 
  - Added `\Wizaplace\SDK\Catalog\Category::getCategoryPath`
+ - Added `\Wizaplace\SDK\User\UserService::registerWithFullInfos`
 
 ### Bugfixes
 

--- a/src/User/RegisterUserCommand.php
+++ b/src/User/RegisterUserCommand.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+declare(strict_types = 1);
+
+namespace Wizaplace\SDK\User;
+
+class RegisterUserCommand
+{
+    /** @var string */
+    private $email;
+
+    /** @var string */
+    private $password;
+
+    /** @var UserTitle|null */
+    private $title;
+
+    /** @var string|null */
+    private $firstName;
+
+    /** @var string|null */
+    private $lastName;
+
+    /** @var \DateTimeInterface|null */
+    private $birthday;
+
+    /** @var UpdateUserAddressCommand|null */
+    private $billing;
+
+    /** @var UpdateUserAddressCommand|null */
+    private $shipping;
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): void
+    {
+        $this->password = $password;
+    }
+
+    public function getTitle(): ?UserTitle
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?UserTitle $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): void
+    {
+        $this->firstName = $firstName;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(?string $lastName): void
+    {
+        $this->lastName = $lastName;
+    }
+
+    public function getBirthday(): ?\DateTimeInterface
+    {
+        return $this->birthday;
+    }
+
+    public function setBirthday(?\DateTimeInterface $birthday): void
+    {
+        $this->birthday = $birthday;
+    }
+
+    public function getBilling(): ?UpdateUserAddressCommand
+    {
+        return $this->billing;
+    }
+
+    public function setBilling(?UpdateUserAddressCommand $billing): void
+    {
+        $this->billing = $billing;
+    }
+
+    public function getShipping(): ?UpdateUserAddressCommand
+    {
+        return $this->shipping;
+    }
+
+    public function setShipping(?UpdateUserAddressCommand $shipping): void
+    {
+        $this->shipping = $shipping;
+    }
+}

--- a/src/User/RegisterUserCommand.php
+++ b/src/User/RegisterUserCommand.php
@@ -7,7 +7,7 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\User;
 
-class RegisterUserCommand
+final class RegisterUserCommand
 {
     /** @var string */
     private $email;

--- a/src/User/UserService.php
+++ b/src/User/UserService.php
@@ -100,7 +100,6 @@ final class UserService extends AbstractService
         string $firstName = '',
         string $lastName = ''
     ): int {
-
         try {
             $userData = $this->client->post(
                 'users',

--- a/src/User/UserService.php
+++ b/src/User/UserService.php
@@ -141,7 +141,7 @@ final class UserService extends AbstractService
                         'birthday' => $command->getBirthday()->format(self::BIRTHDAY_FORMAT),
                         'billing' => self::serializeUserAddressUpdate($command->getBilling()),
                         'shipping' => self::serializeUserAddressUpdate($command->getShipping()),
-                    ]
+                    ],
                 ]
             );
         } catch (ClientException $e) {

--- a/src/User/UserService.php
+++ b/src/User/UserService.php
@@ -100,6 +100,7 @@ final class UserService extends AbstractService
         string $firstName = '',
         string $lastName = ''
     ): int {
+
         try {
             $userData = $this->client->post(
                 'users',
@@ -110,6 +111,37 @@ final class UserService extends AbstractService
                         'firstName' => $firstName,
                         'lastName' => $lastName,
                     ],
+                ]
+            );
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 409) {
+                throw new UserAlreadyExists($e);
+            }
+            throw $e;
+        }
+
+        return $userData['id'];
+    }
+
+    /**
+     * @throws UserAlreadyExists
+     */
+    public function registerWithFullInfos(RegisterUserCommand $command): int
+    {
+        try {
+            $userData = $this->client->post(
+                'users',
+                [
+                    RequestOptions::FORM_PARAMS => [
+                        'email' => $command->getEmail(),
+                        'password' => $command->getPassword(),
+                        'firstName' => $command->getFirstName(),
+                        'lastName' => $command->getLastName(),
+                        'title' => $command->getTitle()->getValue(),
+                        'birthday' => $command->getBirthday()->format(self::BIRTHDAY_FORMAT),
+                        'billing' => self::serializeUserAddressUpdate($command->getBilling()),
+                        'shipping' => self::serializeUserAddressUpdate($command->getShipping()),
+                    ]
                 ]
             );
         } catch (ClientException $e) {

--- a/tests/User/UserServiceTest/testCreateUserWithFullInfos.yml
+++ b/tests/User/UserServiceTest/testCreateUserWithFullInfos.yml
@@ -1,0 +1,82 @@
+
+-
+    request:
+        method: POST
+        url: 'http://wizaplace.loc/api/v1/users'
+        headers:
+            Host: wizaplace.loc
+            Expect: null
+            Accept-Encoding: null
+            Content-Type: application/x-www-form-urlencoded
+            User-Agent: Wizaplace-PHP-SDK/dev-master@beff0af
+            VCR-index: '0'
+            Accept: null
+        body: 'email=user%40example.com&password=password&firstName=Jane&lastName=Doe&title=mrs&birthday=1998-07-12&billing%5Btitle%5D=mrs&billing%5Bfirstname%5D=Jane&billing%5Blastname%5D=Doe&billing%5Bcompany%5D=Wizaplace&billing%5Bphone%5D=0123456789&billing%5Baddress%5D=24+rue+de+la+gare&billing%5Bzipcode%5D=69009&billing%5Bcity%5D=Lyon&billing%5Bcountry%5D=France&shipping%5Btitle%5D=mrs&shipping%5Bfirstname%5D=Jane&shipping%5Blastname%5D=Doe&shipping%5Bcompany%5D=Wizaplace&shipping%5Bphone%5D=0123456789&shipping%5Baddress%5D=24+rue+de+la+gare&shipping%5Bzipcode%5D=69009&shipping%5Bcity%5D=Lyon&shipping%5Bcountry%5D=France'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            Date: 'Mon, 11 Jun 2018 12:56:24 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 0ce507
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/0ce507'
+            Set-Cookie: 'sf_redirect=%7B%22token%22%3A%220ce507%22%2C%22route%22%3A%22api_user_register%22%2C%22method%22%3A%22POST%22%2C%22controller%22%3A%22marketplace.user.api.usercontroller%3AregisterAction%22%2C%22status_code%22%3A201%2C%22status_text%22%3A%22Created%22%7D; path=/; httponly'
+            Content-Length: '9'
+            Content-Type: application/json
+        body: '{"id":13}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/users/authenticate'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            Authorization: 'Basic dXNlckBleGFtcGxlLmNvbTpwYXNzd29yZA=='
+            User-Agent: Wizaplace-PHP-SDK/dev-master@beff0af
+            VCR-index: '1'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Mon, 11 Jun 2018 12:56:25 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: c564d9
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/c564d9'
+            Content-Length: '61'
+            Content-Type: application/json
+        body: '{"id":13,"apiKey":"0H+6ljo1ZJy7XEn6z36ZENlGDOZyTxq7NrVn8svV"}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/users/13'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            User-Agent: Wizaplace-PHP-SDK/dev-master@beff0af
+            Authorization: 'token 0H+6ljo1ZJy7XEn6z36ZENlGDOZyTxq7NrVn8svV'
+            VCR-index: '2'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Mon, 11 Jun 2018 12:56:25 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: aefd57
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/aefd57'
+            Content-Length: '657'
+            Content-Type: application/json
+        body: '{"id":13,"title":"mrs","email":"user@example.com","companyId":null,"firstName":"Jane","lastName":"Doe","birthday":"1998-07-12","loyaltyIdentifier":null,"addresses":{"billing":{"title":"mrs","firstname":"Jane","lastname":"Doe","company":"Wizaplace","phone":"0123456789","address":"24 rue de la gare","address_2":"","zipcode":"69009","city":"Lyon","country":"Fr","37":3,"38":3,"40":"Wizaplace","39":"Wizaplace"},"shipping":{"title":"mrs","firstname":"Jane","lastname":"Doe","company":"Wizaplace","phone":"0123456789","address":"24 rue de la gare","address_2":"","zipcode":"69009","city":"Lyon","country":"Fr","37":3,"38":3,"40":"Wizaplace","39":"Wizaplace"}}}'


### PR DESCRIPTION
En rapport avec [#5347](https://github.com/wizaplace/wizaplace/pull/5347)

Ajout de la possibilité de register l'utilisateur avec tous ses champs (addresses, birthday, title)

Pas du tout sûr de moi sur la sémantique, je suis prêt à changer tous les noms si besoin 😄 

## Checklist

- [x] Changelog updated
