### PR TITLE
WIZ-79 add method to create an organisation's group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - Added `\Wizapalce\SDK\Catalog\Review\ReviewService::canUserReviewProduct`
+- Added `\Wizaplace\SDK\Organisation\OrganisationService::createGroup`
 
 ### Corrections
 

--- a/src/Organisation/OrganisationService.php
+++ b/src/Organisation/OrganisationService.php
@@ -409,6 +409,43 @@ class OrganisationService extends AbstractService
     }
 
     /**
+     * https://sandbox.wizaplace.com/api/v1/doc/#/paths/~1organisations~1{organisationId}~1groups/post
+     *
+     * @param string $organisationId
+     * @param string $name
+     * @param string $type
+     *
+     * @return array|null
+     * @throws AuthenticationRequired
+     * @throws NotFound
+     * @throws UserDoesntBelongToOrganisation
+     */
+    public function createGroup(string $organisationId, string $name, string $type)
+    {
+        $this->client->mustBeAuthenticated();
+
+        try {
+            return $this->client->post(
+                "organisations/{$organisationId}/groups",
+                [
+                    RequestOptions::FORM_PARAMS => [
+                        "name" => $name,
+                        "type" => $type,
+                    ],
+                ]
+            );
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 403) {
+                throw new UserDoesntBelongToOrganisation("You don't belong to the administrator group", $e);
+            }
+            if ($e->getResponse()->getStatusCode() === 404) {
+                throw new NotFound("The organisation doesn't exist", $e);
+            }
+            throw $e;
+        }
+    }
+
+    /**
      * Allow to add a new user to the group.
      *
      * @param string $groupId

--- a/tests/Organisation/OrganisationServiceTest.php
+++ b/tests/Organisation/OrganisationServiceTest.php
@@ -538,7 +538,7 @@ final class OrganisationServiceTest extends ApiTestCase
         if (is_string($organisationId)) {
             $responseData = $organisationService->createGroup($organisationId, "name", "type");
 
-            $this->assertRegexp(
+            $this->assertRegExp(
                 '~^[a-zA-Z0-9]{8}(-[a-zA-Z0-9]{4}){4}[a-zA-Z0-9]{8}$~',
                 $responseData['id']
             );

--- a/tests/Organisation/OrganisationServiceTest.php
+++ b/tests/Organisation/OrganisationServiceTest.php
@@ -529,6 +529,22 @@ final class OrganisationServiceTest extends ApiTestCase
         $this->assertInstanceOf(User::class, $user);
     }
 
+    public function testCanCreateAnOrganisationGroup()
+    {
+        $organisationService = $this->buildOrganisationService('admin@wizaplace.com', 'password');
+
+        $organisationId = $this->getOrganisationId();
+
+        if (is_string($organisationId)) {
+            $responseData = $organisationService->createGroup($organisationId, "name", "type");
+
+            $this->assertRegexp(
+                '~^[a-zA-Z0-9]{8}(-[a-zA-Z0-9]{4}){4}[a-zA-Z0-9]{8}$~',
+                $responseData['id']
+            );
+        }
+    }
+
     /**
      * Return the id of an organisation, if found, else false
      * @param int $index

--- a/tests/Organisation/OrganisationServiceTest/testCanCreateAnOrganisationGroup.yml
+++ b/tests/Organisation/OrganisationServiceTest/testCanCreateAnOrganisationGroup.yml
@@ -1,0 +1,109 @@
+
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/users/authenticate'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/WIZ-79-create-organisation-group@d700c13
+            VCR-index: '0'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Wed, 26 Sep 2018 12:30:42 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 446bcf
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/446bcf'
+            Content-Length: '60'
+            Content-Type: application/json
+        body: '{"id":2,"apiKey":"PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK"}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/users/authenticate'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/WIZ-79-create-organisation-group@d700c13
+            VCR-index: '1'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Wed, 26 Sep 2018 12:30:43 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: a667ec
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/a667ec'
+            Content-Length: '60'
+            Content-Type: application/json
+        body: '{"id":2,"apiKey":"PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK"}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/organisations'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/WIZ-79-create-organisation-group@d700c13
+            Authorization: 'token PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK'
+            VCR-index: '2'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Wed, 26 Sep 2018 12:30:43 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 62a7fe
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/62a7fe'
+            Content-Length: '1146'
+            Content-Type: application/json
+        body: '{"total":2,"count":2,"_embedded":{"organisations":[{"id":"eee0f1f5-c187-11e8-8db2-080027ea4cb6","name":"University of New York","businessName":"University of New York","siret":"44229377500031","vatNumber":"FR99999999999","businessUnitCode":"NTW","businessUnitName":"Network Infrastructure","address":{"address":"194 Lindale Avenue","additionalAddress":"","zipCode":"94801","city":"Richmond","state":"","country":"US"},"shippingAddress":{"address":"4917 Snyder Avenue","additionalAddress":"","zipCode":"28209","city":"North Carolina","state":"","country":"US"},"status":"pending"},{"id":"ef116ef9-c187-11e8-8db2-080027ea4cb6","name":"University of Southern California","businessName":"Southern California","siret":"80295478500028","vatNumber":"FR63802954785","businessUnitCode":"IT","businessUnitName":"Information Technology","address":{"address":"42228 Hunter Summit Suite 058","additionalAddress":"","zipCode":"13736-4550","city":"Bettyeburgh","state":"","country":"FR"},"shippingAddress":{"address":"99410 Dach Views Apt. 994","additionalAddress":"","zipCode":"00229","city":"West Geraldport","state":"","country":"FR"},"status":"approved"}]}}'
+-
+    request:
+        method: POST
+        url: 'http://wizaplace.loc/api/v1/organisations/eee0f1f5-c187-11e8-8db2-080027ea4cb6/groups'
+        headers:
+            Host: wizaplace.loc
+            Expect: null
+            Accept-Encoding: null
+            Content-Type: application/x-www-form-urlencoded
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/WIZ-79-create-organisation-group@d700c13
+            Authorization: 'token PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK'
+            VCR-index: '3'
+            Accept: null
+        body: 'name=name&type=type'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            Date: 'Wed, 26 Sep 2018 12:30:44 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: b27f45
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/b27f45'
+            Set-Cookie: 'sf_redirect=%7B%22token%22%3A%22b27f45%22%2C%22route%22%3A%22api_organisation_post_groups%22%2C%22method%22%3A%22POST%22%2C%22controller%22%3A%7B%22class%22%3A%22Wizacha%5C%5CAppBundle%5C%5CController%5C%5CApi%5C%5COrganisation%5C%5COrganisationController%22%2C%22method%22%3A%22addGroupAction%22%2C%22file%22%3A%22%5C%2Fvagrant%5C%2Fsrc%5C%2FAppBundle%5C%2FController%5C%2FApi%5C%2FOrganisation%5C%2FOrganisationController.php%22%2C%22line%22%3A338%7D%2C%22status_code%22%3A201%2C%22status_text%22%3A%22Created%22%7D; path=/; httponly'
+            Content-Length: '45'
+            Content-Type: application/json
+        body: '{"id":"fcf18872-c187-11e8-8db2-080027ea4cb6"}'

--- a/tests/Organisation/OrganisationServiceTest/testCanCreateAnOrganisationGroup.yml
+++ b/tests/Organisation/OrganisationServiceTest/testCanCreateAnOrganisationGroup.yml
@@ -16,15 +16,15 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Wed, 26 Sep 2018 12:30:42 GMT'
+            Date: 'Wed, 26 Sep 2018 12:38:21 GMT'
             Server: 'Apache/2.4.25 (Debian)'
             Cache-Control: 'no-cache, private'
             Content-Language: fr
-            X-Debug-Token: 446bcf
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/446bcf'
+            X-Debug-Token: fb04ea
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/fb04ea'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK"}'
+        body: '{"id":2,"apiKey":"SaW8OwahR9fBcDuq8Leo6udAFIEL+jJRW8eYBrWi"}'
 -
     request:
         method: GET
@@ -42,15 +42,15 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Wed, 26 Sep 2018 12:30:43 GMT'
+            Date: 'Wed, 26 Sep 2018 12:38:22 GMT'
             Server: 'Apache/2.4.25 (Debian)'
             Cache-Control: 'no-cache, private'
             Content-Language: fr
-            X-Debug-Token: a667ec
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/a667ec'
+            X-Debug-Token: 0a2398
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/0a2398'
             Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK"}'
+        body: '{"id":2,"apiKey":"SaW8OwahR9fBcDuq8Leo6udAFIEL+jJRW8eYBrWi"}'
 -
     request:
         method: GET
@@ -59,7 +59,7 @@
             Host: wizaplace.loc
             Accept-Encoding: null
             User-Agent: Wizaplace-PHP-SDK/dev-feature/WIZ-79-create-organisation-group@d700c13
-            Authorization: 'token PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK'
+            Authorization: 'token SaW8OwahR9fBcDuq8Leo6udAFIEL+jJRW8eYBrWi'
             VCR-index: '2'
             Accept: null
     response:
@@ -68,26 +68,26 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Wed, 26 Sep 2018 12:30:43 GMT'
+            Date: 'Wed, 26 Sep 2018 12:38:22 GMT'
             Server: 'Apache/2.4.25 (Debian)'
             Cache-Control: 'no-cache, private'
             Content-Language: fr
-            X-Debug-Token: 62a7fe
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/62a7fe'
+            X-Debug-Token: 188c85
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/188c85'
             Content-Length: '1146'
             Content-Type: application/json
-        body: '{"total":2,"count":2,"_embedded":{"organisations":[{"id":"eee0f1f5-c187-11e8-8db2-080027ea4cb6","name":"University of New York","businessName":"University of New York","siret":"44229377500031","vatNumber":"FR99999999999","businessUnitCode":"NTW","businessUnitName":"Network Infrastructure","address":{"address":"194 Lindale Avenue","additionalAddress":"","zipCode":"94801","city":"Richmond","state":"","country":"US"},"shippingAddress":{"address":"4917 Snyder Avenue","additionalAddress":"","zipCode":"28209","city":"North Carolina","state":"","country":"US"},"status":"pending"},{"id":"ef116ef9-c187-11e8-8db2-080027ea4cb6","name":"University of Southern California","businessName":"Southern California","siret":"80295478500028","vatNumber":"FR63802954785","businessUnitCode":"IT","businessUnitName":"Information Technology","address":{"address":"42228 Hunter Summit Suite 058","additionalAddress":"","zipCode":"13736-4550","city":"Bettyeburgh","state":"","country":"FR"},"shippingAddress":{"address":"99410 Dach Views Apt. 994","additionalAddress":"","zipCode":"00229","city":"West Geraldport","state":"","country":"FR"},"status":"approved"}]}}'
+        body: '{"total":2,"count":2,"_embedded":{"organisations":[{"id":"ff60f184-c188-11e8-8db2-080027ea4cb6","name":"University of New York","businessName":"University of New York","siret":"44229377500031","vatNumber":"FR99999999999","businessUnitCode":"NTW","businessUnitName":"Network Infrastructure","address":{"address":"194 Lindale Avenue","additionalAddress":"","zipCode":"94801","city":"Richmond","state":"","country":"US"},"shippingAddress":{"address":"4917 Snyder Avenue","additionalAddress":"","zipCode":"28209","city":"North Carolina","state":"","country":"US"},"status":"pending"},{"id":"ff7ececc-c188-11e8-8db2-080027ea4cb6","name":"University of Southern California","businessName":"Southern California","siret":"80295478500028","vatNumber":"FR63802954785","businessUnitCode":"IT","businessUnitName":"Information Technology","address":{"address":"42228 Hunter Summit Suite 058","additionalAddress":"","zipCode":"13736-4550","city":"Bettyeburgh","state":"","country":"FR"},"shippingAddress":{"address":"99410 Dach Views Apt. 994","additionalAddress":"","zipCode":"00229","city":"West Geraldport","state":"","country":"FR"},"status":"approved"}]}}'
 -
     request:
         method: POST
-        url: 'http://wizaplace.loc/api/v1/organisations/eee0f1f5-c187-11e8-8db2-080027ea4cb6/groups'
+        url: 'http://wizaplace.loc/api/v1/organisations/ff60f184-c188-11e8-8db2-080027ea4cb6/groups'
         headers:
             Host: wizaplace.loc
             Expect: null
             Accept-Encoding: null
             Content-Type: application/x-www-form-urlencoded
             User-Agent: Wizaplace-PHP-SDK/dev-feature/WIZ-79-create-organisation-group@d700c13
-            Authorization: 'token PVRhsRGKnLINktRKxAfvDif9aMEWkwI7YjQmB9TK'
+            Authorization: 'token SaW8OwahR9fBcDuq8Leo6udAFIEL+jJRW8eYBrWi'
             VCR-index: '3'
             Accept: null
         body: 'name=name&type=type'
@@ -97,13 +97,13 @@
             code: '201'
             message: Created
         headers:
-            Date: 'Wed, 26 Sep 2018 12:30:44 GMT'
+            Date: 'Wed, 26 Sep 2018 12:38:22 GMT'
             Server: 'Apache/2.4.25 (Debian)'
             Cache-Control: 'no-cache, private'
             Content-Language: fr
-            X-Debug-Token: b27f45
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/b27f45'
-            Set-Cookie: 'sf_redirect=%7B%22token%22%3A%22b27f45%22%2C%22route%22%3A%22api_organisation_post_groups%22%2C%22method%22%3A%22POST%22%2C%22controller%22%3A%7B%22class%22%3A%22Wizacha%5C%5CAppBundle%5C%5CController%5C%5CApi%5C%5COrganisation%5C%5COrganisationController%22%2C%22method%22%3A%22addGroupAction%22%2C%22file%22%3A%22%5C%2Fvagrant%5C%2Fsrc%5C%2FAppBundle%5C%2FController%5C%2FApi%5C%2FOrganisation%5C%2FOrganisationController.php%22%2C%22line%22%3A338%7D%2C%22status_code%22%3A201%2C%22status_text%22%3A%22Created%22%7D; path=/; httponly'
+            X-Debug-Token: ad7ae8
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/ad7ae8'
+            Set-Cookie: 'sf_redirect=%7B%22token%22%3A%22ad7ae8%22%2C%22route%22%3A%22api_organisation_post_groups%22%2C%22method%22%3A%22POST%22%2C%22controller%22%3A%7B%22class%22%3A%22Wizacha%5C%5CAppBundle%5C%5CController%5C%5CApi%5C%5COrganisation%5C%5COrganisationController%22%2C%22method%22%3A%22addGroupAction%22%2C%22file%22%3A%22%5C%2Fvagrant%5C%2Fsrc%5C%2FAppBundle%5C%2FController%5C%2FApi%5C%2FOrganisation%5C%2FOrganisationController.php%22%2C%22line%22%3A338%7D%2C%22status_code%22%3A201%2C%22status_text%22%3A%22Created%22%7D; path=/; httponly'
             Content-Length: '45'
             Content-Type: application/json
-        body: '{"id":"fcf18872-c187-11e8-8db2-080027ea4cb6"}'
+        body: '{"id":"0e4b61cf-c189-11e8-8db2-080027ea4cb6"}'


### PR DESCRIPTION
Ajout de la méthode `\Wizaplace\SDK\Organisation\OrganisationService::createGroup` qui permet de créer un groupe pour une organisation. L'identifiant du nouveau groupe est retourné