### PR TITLE
Refactor files and multipart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### New features
 
 - Added `\Wizaplace\SDK\Pim\MultiVendorProduct\MultiVendorProductService::addImageToMultivendorProduct`
-- Added `\Wizaplace\SDK\Organisation\OrganisationService::getGroupUsers
+- Added `\Wizaplace\SDK\Organisation\OrganisationService::getGroupUsers`
 
 ### Corrections
 

--- a/src/File/FileService.php
+++ b/src/File/FileService.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+
+namespace Wizaplace\SDK\File;
+
+use Psr\Http\Message\StreamInterface;
+use Wizaplace\SDK\ArrayableInterface;
+
+class FileService
+{
+    /** @var string */
+    private $name;
+
+    /** @var StreamInterface */
+    private $contents;
+
+    /** @var string */
+    private $filename;
+
+    public function __construct(string $name, StreamInterface $contents, string $filename)
+    {
+        $this->name = $name;
+        $this->contents = $contents;
+        $this->filename = $filename;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return StreamInterface
+     */
+    public function getContents(): StreamInterface
+    {
+        return $this->contents;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    /**
+     * @param array $data
+     * @param array $files
+     *
+     * @return array
+     */
+    public static function createMultipartArray(array $data, array $files) : array
+    {
+        $dataToSend = [];
+
+        $flatArray = self::flattenArray($data);
+
+        foreach ($flatArray as $key => $value) {
+            $dataToSend[] = [
+                'name'  => $key,
+                'contents' => $value,
+            ];
+        }
+
+        foreach ($files as $file) {
+            $dataToSend[] = [
+                'name' => $file->getName(),
+                'contents' => $file->getContents(),
+            ];
+        }
+
+        return $dataToSend;
+    }
+
+    /**
+     * This method help to have an array compliant to Guzzle for multipart POST/PUT for the organisation process
+     * There are exception in the process for OrganisationAddress and OrganisationAdministrator which needs to be transformed to array
+     * prior to processing
+     *
+     * Ex:
+     * ['name' => 'obiwan', ['address' => ['street' => 'main street', 'city' => 'Mos Esley']]
+     * needs to be flatten to
+     * ['name' => 'obiwan', 'address[street]' => 'main street', 'address[city]' => 'Mos esley']
+     *
+     * @param array $array
+     * @param string $originalKey
+     * @return array
+     */
+    private static function flattenArray(array $array, string $originalKey = '')
+    {
+        $output = [];
+
+        foreach ($array as $key => $value) {
+            $newKey = $originalKey;
+            if (empty($originalKey)) {
+                $newKey .= $key;
+            } else {
+                $newKey .= '['.$key.']';
+            }
+
+            if (is_array($value)) {
+                $output = array_merge($output, self::flattenArray($value, $newKey));
+            } elseif ($value instanceof ArrayableInterface) {
+                $output = array_merge($output, self::flattenArray($value->toArray(), $newKey));
+            } else {
+                $output[$newKey] = $value;
+            }
+        }
+
+        return $output;
+    }
+}

--- a/src/Organisation/OrganisationFile.php
+++ b/src/Organisation/OrganisationFile.php
@@ -6,47 +6,8 @@
 
 namespace Wizaplace\SDK\Organisation;
 
-use Psr\Http\Message\StreamInterface;
+use Wizaplace\SDK\File\FileService;
 
-class OrganisationFile
+class OrganisationFile extends FileService
 {
-    /** @var string */
-    private $name;
-
-    /** @var StreamInterface */
-    private $contents;
-
-    /** @var string */
-    private $filename;
-
-    public function __construct(string $name, StreamInterface $contents, string $filename)
-    {
-        $this->name = $name;
-        $this->contents = $contents;
-        $this->filename = $filename;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
-     * @return StreamInterface
-     */
-    public function getContents(): StreamInterface
-    {
-        return $this->contents;
-    }
-
-    /**
-     * @return string
-     */
-    public function getFilename(): string
-    {
-        return $this->filename;
-    }
 }

--- a/src/Organisation/OrganisationService.php
+++ b/src/Organisation/OrganisationService.php
@@ -11,11 +11,11 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\RequestOptions;
 use Symfony\Component\HttpFoundation\Response;
 use Wizaplace\SDK\AbstractService;
-use Wizaplace\SDK\ArrayableInterface;
 use Wizaplace\SDK\Authentication\AuthenticationRequired;
 use Wizaplace\SDK\Authentication\BadCredentials;
 use Wizaplace\SDK\Exception\NotFound;
 use Wizaplace\SDK\Exception\UserDoesntBelongToOrganisation;
+use Wizaplace\SDK\File\FileService;
 use Wizaplace\SDK\User\User;
 
 class OrganisationService extends AbstractService
@@ -44,7 +44,7 @@ class OrganisationService extends AbstractService
 
         try {
             $registrationReturn = $this->client->post('organisations/registrations', [
-                RequestOptions::MULTIPART => $this->createMultipartArray($data, $organisation->getFiles()),
+                RequestOptions::MULTIPART => FileService::createMultipartArray($data, $organisation->getFiles()),
             ]);
 
             return $registrationReturn;
@@ -156,7 +156,7 @@ class OrganisationService extends AbstractService
 
         try {
             $response = $this->client->post("organisations/{$organisationId}/users", [
-                RequestOptions::MULTIPART => $this->createMultipartArray($data, $files),
+                RequestOptions::MULTIPART => FileService::createMultipartArray($data, $files),
             ]);
 
             return new User($response);
@@ -635,72 +635,5 @@ class OrganisationService extends AbstractService
                     throw $e;
             }
         }
-    }
-
-    /**
-     * This method help to have an array compliant to Guzzle for multipart POST/PUT for the organisation process
-     * There are exception in the process for OrganisationAddress and OrganisationAdministrator which needs to be transformed to array
-     * prior to processing
-     *
-     * Ex:
-     * ['name' => 'obiwan', ['address' => ['street' => 'main street', 'city' => 'Mos Esley']]
-     * needs to be flatten to
-     * ['name' => 'obiwan', 'address[street]' => 'main street', 'address[city]' => 'Mos esley']
-     *
-     * @param array $array
-     * @param string $originalKey
-     * @return array
-     */
-    private function flattenArray(array $array, string $originalKey = '')
-    {
-        $output = [];
-
-        foreach ($array as $key => $value) {
-            $newKey = $originalKey;
-            if (empty($originalKey)) {
-                $newKey .= $key;
-            } else {
-                $newKey .= '['.$key.']';
-            }
-
-            if (is_array($value)) {
-                $output = array_merge($output, $this->flattenArray($value, $newKey));
-            } elseif ($value instanceof ArrayableInterface) {
-                $output = array_merge($output, $this->flattenArray($value->toArray(), $newKey));
-            } else {
-                $output[$newKey] = $value;
-            }
-        }
-
-        return $output;
-    }
-
-    /**
-     * @param array              $data
-     * @param OrganisationFile[] $files
-     *
-     * @return array
-     */
-    private function createMultipartArray(array $data, array $files) : array
-    {
-        $dataToSend = [];
-
-        $flatArray = $this->flattenArray($data);
-
-        foreach ($flatArray as $key => $value) {
-            $dataToSend[] = [
-                'name'  => $key,
-                'contents' => $value,
-            ];
-        }
-
-        foreach ($files as $file) {
-            $dataToSend[] = [
-                'name' => $file->getName(),
-                'contents' => $file->getContents(),
-            ];
-        }
-
-        return $dataToSend;
     }
 }

--- a/src/Pim/MultiVendorProduct/MultiVendorProductFile.php
+++ b/src/Pim/MultiVendorProduct/MultiVendorProductFile.php
@@ -6,8 +6,8 @@
 
 namespace Wizaplace\SDK\Pim\MultiVendorProduct;
 
-use Wizaplace\SDK\Organisation\OrganisationFile;
+use Wizaplace\SDK\File\FileService;
 
-class MultiVendorProductFile extends OrganisationFile
+class MultiVendorProductFile extends FileService
 {
 }

--- a/src/Pim/MultiVendorProduct/MultiVendorProductService.php
+++ b/src/Pim/MultiVendorProduct/MultiVendorProductService.php
@@ -10,9 +10,9 @@ namespace Wizaplace\SDK\Pim\MultiVendorProduct;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\RequestOptions;
 use Wizaplace\SDK\AbstractService;
-use Wizaplace\SDK\ArrayableInterface;
 use Wizaplace\SDK\Exception\NotFound;
 use Wizaplace\SDK\Exception\SomeParametersAreInvalid;
+use Wizaplace\SDK\File\FileService;
 use function theodorejb\polycast\to_string;
 
 final class MultiVendorProductService extends AbstractService
@@ -72,7 +72,7 @@ final class MultiVendorProductService extends AbstractService
 
         try {
             $response = $this->client->post("pim/multi-vendor-products/{$mvpId}/images", [
-                RequestOptions::MULTIPART => $this->createMultipartArray([], $files),
+                RequestOptions::MULTIPART => FileService::createMultipartArray([], $files),
             ]);
         } catch (ClientException $e) {
             if ($e->getCode() === 404) {
@@ -85,72 +85,5 @@ final class MultiVendorProductService extends AbstractService
         }
 
         return new MultiVendorProduct($response);
-    }
-
-    /**
-     * This method help to have an array compliant to Guzzle for multipart POST/PUT for the organisation process
-     * There are exception in the process for OrganisationAddress and OrganisationAdministrator which needs to be transformed to array
-     * prior to processing
-     *
-     * Ex:
-     * ['name' => 'obiwan', ['address' => ['street' => 'main street', 'city' => 'Mos Esley']]
-     * needs to be flatten to
-     * ['name' => 'obiwan', 'address[street]' => 'main street', 'address[city]' => 'Mos esley']
-     *
-     * @param array $array
-     * @param string $originalKey
-     * @return array
-     */
-    private function flattenArray(array $array, string $originalKey = '')
-    {
-        $output = [];
-
-        foreach ($array as $key => $value) {
-            $newKey = $originalKey;
-            if (empty($originalKey)) {
-                $newKey .= $key;
-            } else {
-                $newKey .= '['.$key.']';
-            }
-
-            if (is_array($value)) {
-                $output = array_merge($output, $this->flattenArray($value, $newKey));
-            } elseif ($value instanceof ArrayableInterface) {
-                $output = array_merge($output, $this->flattenArray($value->toArray(), $newKey));
-            } else {
-                $output[$newKey] = $value;
-            }
-        }
-
-        return $output;
-    }
-
-    /**
-     * @param array                    $data
-     * @param MultiVendorProductFile[] $files
-     *
-     * @return array
-     */
-    private function createMultipartArray(array $data, array $files) : array
-    {
-        $dataToSend = [];
-
-        $flatArray = $this->flattenArray($data);
-
-        foreach ($flatArray as $key => $value) {
-            $dataToSend[] = [
-                'name'  => $key,
-                'contents' => $value,
-            ];
-        }
-
-        foreach ($files as $file) {
-            $dataToSend[] = [
-                'name' => $file->getName(),
-                'contents' => $file->getContents(),
-            ];
-        }
-
-        return $dataToSend;
     }
 }

--- a/tests/Company/CompanyServiceTest.php
+++ b/tests/Company/CompanyServiceTest.php
@@ -8,8 +8,6 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Tests\Company;
 
 use GuzzleHttp\Exception\ClientException;
-use PHPUnit_Framework_MockObject_MockObject;
-use Psr\Http\Message\UploadedFileInterface;
 use Wizaplace\SDK\Authentication\AuthenticationRequired;
 use Wizaplace\SDK\Company\Company;
 use Wizaplace\SDK\Company\CompanyRegistration;
@@ -19,7 +17,7 @@ use Wizaplace\SDK\Company\CompanyUpdateCommand;
 use Wizaplace\SDK\Company\UnauthenticatedCompanyRegistration;
 use Wizaplace\SDK\Exception\CompanyNotFound;
 use Wizaplace\SDK\Tests\ApiTestCase;
-use function GuzzleHttp\Psr7\stream_for;
+use Wizaplace\SDK\Tests\File\FileTestService;
 
 /**
  * @see CompanyService
@@ -45,8 +43,8 @@ final class CompanyServiceTest extends ApiTestCase
         $companyRegistration->setUrl('https://acme.example.com/');
         $companyRegistration->setExtra(['driving_license_number' => '654987321']);
 
-        $companyRegistration->addUploadedFile('rib', $this->mockUploadedFile('minimal.pdf'));
-        $companyRegistration->addUploadedFile('idCard', $this->mockUploadedFile('minimal.pdf'));
+        $companyRegistration->addUploadedFile('rib', FileTestService::mockUploadedFile('minimal.pdf'));
+        $companyRegistration->addUploadedFile('idCard', FileTestService::mockUploadedFile('minimal.pdf'));
 
         $companyService = $this->buildUserCompanyService('customer-3@world-company.com', 'password-customer-3');
 
@@ -87,7 +85,7 @@ final class CompanyServiceTest extends ApiTestCase
 
 
         // Update file
-        $file = $this->mockUploadedFile('minimal.pdf');
+        $file = FileTestService::mockUploadedFile('minimal.pdf');
 
         $update = $companyService->updateFile($company->getId(), 'idCard', [
             'name'     => "idCard",
@@ -147,7 +145,7 @@ final class CompanyServiceTest extends ApiTestCase
     public function testUploadingBadExtensionRegistrationFiles()
     {
         $companyRegistration = new CompanyRegistration('4CME Test Inc', 'acme4@example.com');
-        $companyRegistration->addUploadedFile('rib', $this->mockUploadedFile('dummy.txt'));
+        $companyRegistration->addUploadedFile('rib', FileTestService::mockUploadedFile('dummy.txt'));
         $companyService = $this->buildUserCompanyService('customer-3@world-company.com', 'password-customer-3');
 
         $result = $companyService->register($companyRegistration);
@@ -245,17 +243,5 @@ final class CompanyServiceTest extends ApiTestCase
         $apiClient->authenticate($email, $password);
 
         return new CompanyService($apiClient);
-    }
-
-    private function mockUploadedFile(string $filename): UploadedFileInterface
-    {
-        $path = __DIR__.'/../fixtures/files/'.$filename;
-
-        /** @var UploadedFileInterface|PHPUnit_Framework_MockObject_MockObject $file */
-        $file = $this->createMock(UploadedFileInterface::class);
-        $file->expects($this->once())->method('getStream')->willReturn(stream_for(fopen($path, 'r')));
-        $file->expects($this->once())->method('getClientFilename')->willReturn($filename);
-
-        return $file;
     }
 }

--- a/tests/File/FileTestService.php
+++ b/tests/File/FileTestService.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (c) Wizacha
+ * @license Proprietary
+ */
+
+namespace Wizaplace\SDK\Tests\File;
+
+use Psr\Http\Message\UploadedFileInterface;
+use Wizaplace\SDK\Tests\ApiTestCase;
+use function GuzzleHttp\Psr7\stream_for;
+
+class FileTestService extends ApiTestCase
+{
+    public static function mockUploadedFile(string $filename): UploadedFileInterface
+    {
+        $path = __DIR__.'/../fixtures/files/'.$filename;
+
+        /** @var UploadedFileInterface|\PHPUnit_Framework_MockObject_MockObject $file */
+        $file = (new FileTestService())->createMock(UploadedFileInterface::class);
+        $file->expects(parent::once())->method('getStream')->willReturn(stream_for(fopen($path, 'r')));
+        $file->expects(parent::once())->method('getClientFilename')->willReturn($filename);
+
+        return $file;
+    }
+}

--- a/tests/Organisation/OrganisationServiceTest.php
+++ b/tests/Organisation/OrganisationServiceTest.php
@@ -8,19 +8,17 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Tests\Organisation;
 
-use Psr\Http\Message\UploadedFileInterface;
 use Wizaplace\SDK\Authentication\BadCredentials;
 use Wizaplace\SDK\Exception\UserDoesntBelongToOrganisation;
 use Wizaplace\SDK\Organisation\Organisation;
 use Wizaplace\SDK\Organisation\OrganisationAddress;
 use Wizaplace\SDK\Organisation\OrganisationBasket;
-use Wizaplace\SDK\Organisation\OrganisationFile;
 use Wizaplace\SDK\Organisation\OrganisationGroup;
 use Wizaplace\SDK\Organisation\OrganisationOrder;
 use Wizaplace\SDK\Organisation\OrganisationService;
 use Wizaplace\SDK\Tests\ApiTestCase;
+use Wizaplace\SDK\Tests\File\FileTestService;
 use Wizaplace\SDK\User\User;
-use function GuzzleHttp\Psr7\stream_for;
 
 final class OrganisationServiceTest extends ApiTestCase
 {
@@ -32,8 +30,8 @@ final class OrganisationServiceTest extends ApiTestCase
 
         $organisation = new Organisation($data);
 
-        $organisation->addUploadedFile('identityCard', $this->mockUploadedFile('minimal.pdf'));
-        $organisation->addUploadedFile('proofOfAppointment', $this->mockUploadedFile('minimal.pdf'));
+        $organisation->addUploadedFile('identityCard', FileTestService::mockUploadedFile('minimal.pdf'));
+        $organisation->addUploadedFile('proofOfAppointment', FileTestService::mockUploadedFile('minimal.pdf'));
 
         $responseData = $organisationService->register($organisation);
 
@@ -60,8 +58,8 @@ final class OrganisationServiceTest extends ApiTestCase
 
         $organisation = new Organisation($data);
 
-        $organisation->addUploadedFile('identityCard', $this->mockUploadedFile('minimal.pdf'));
-        $organisation->addUploadedFile('proofOfAppointment', $this->mockUploadedFile('minimal.pdf'));
+        $organisation->addUploadedFile('identityCard', FileTestService::mockUploadedFile('minimal.pdf'));
+        $organisation->addUploadedFile('proofOfAppointment', FileTestService::mockUploadedFile('minimal.pdf'));
 
         $responseData = $organisationService->register($organisation);
 
@@ -88,8 +86,8 @@ final class OrganisationServiceTest extends ApiTestCase
 
         $organisation = new Organisation($data);
 
-        $organisation->addUploadedFile('identityCard', $this->mockUploadedFile('minimal.pdf'));
-        $organisation->addUploadedFile('proofOfAppointment', $this->mockUploadedFile('minimal.pdf'));
+        $organisation->addUploadedFile('identityCard', FileTestService::mockUploadedFile('minimal.pdf'));
+        $organisation->addUploadedFile('proofOfAppointment', FileTestService::mockUploadedFile('minimal.pdf'));
 
         $this->expectExceptionCode(403);
         $organisationService->register($organisation);
@@ -516,12 +514,12 @@ final class OrganisationServiceTest extends ApiTestCase
         ];
 
 
-        $idCard = $this->mockUploadedFile('minimal.pdf');
-        $proof  = $this->mockUploadedFile('minimal.pdf');
+        $idCard = FileTestService::mockUploadedFile('minimal.pdf');
+        $proof  = FileTestService::mockUploadedFile('minimal.pdf');
 
         $files = [
-            new OrganisationFile("identityCard", $idCard->getStream(), $idCard->getClientFilename()),
-            new OrganisationFile("proofOfAppointment", $proof->getStream(), $proof->getClientFilename()),
+            new OrganisationFileService("identityCard", $idCard->getStream(), $idCard->getClientFilename()),
+            new OrganisationFileService("proofOfAppointment", $proof->getStream(), $proof->getClientFilename()),
         ];
 
         $user = $organisationService->addNewUser((string) $organisationId, $data, $files);
@@ -606,18 +604,6 @@ final class OrganisationServiceTest extends ApiTestCase
         }
 
         return new OrganisationService($apiClient);
-    }
-
-    private function mockUploadedFile(string $filename): UploadedFileInterface
-    {
-        $path = __DIR__.'/../fixtures/files/'.$filename;
-
-        /** @var UploadedFileInterface|\PHPUnit_Framework_MockObject_MockObject $file */
-        $file = $this->createMock(UploadedFileInterface::class);
-        $file->expects($this->once())->method('getStream')->willReturn(stream_for(fopen($path, 'r')));
-        $file->expects($this->once())->method('getClientFilename')->willReturn($filename);
-
-        return $file;
     }
 
     /**

--- a/tests/Pim/MultiVendorProduct/MultiVendorProductServiceTest.php
+++ b/tests/Pim/MultiVendorProduct/MultiVendorProductServiceTest.php
@@ -7,14 +7,13 @@ declare(strict_types=1);
 
 namespace Wizaplace\SDK\Tests\Pim\MultiVendorProduct;
 
-use Psr\Http\Message\UploadedFileInterface;
 use Wizaplace\SDK\Exception\SomeParametersAreInvalid;
 use Wizaplace\SDK\Pim\MultiVendorProduct\MultiVendorProduct;
 use Wizaplace\SDK\Pim\MultiVendorProduct\MultiVendorProductFile;
 use Wizaplace\SDK\Pim\MultiVendorProduct\MultiVendorProductService;
 use Wizaplace\SDK\Pim\MultiVendorProduct\MultiVendorProductStatus;
 use Wizaplace\SDK\Tests\ApiTestCase;
-use function GuzzleHttp\Psr7\stream_for;
+use Wizaplace\SDK\Tests\File\FileTestService;
 
 final class MultiVendorProductServiceTest extends ApiTestCase
 {
@@ -215,7 +214,7 @@ final class MultiVendorProductServiceTest extends ApiTestCase
         $service = $this->buildMultiVendorProductService();
         $uuid = '0adaf6bc-d362-34be-b72f-42d5aa3b4a4e';
 
-        $image = $this->mockUploadedFile("favicon.png");
+        $image = FileTestService::mockUploadedFile("favicon.png");
 
         $files = [
             new MultiVendorProductFile('file', $image->getStream(), $image->getClientFilename()),
@@ -233,17 +232,5 @@ final class MultiVendorProductServiceTest extends ApiTestCase
         $apiClient->authenticate($userEmail, $userPassword);
 
         return new MultiVendorProductService($apiClient);
-    }
-
-    private function mockUploadedFile(string $filename): UploadedFileInterface
-    {
-        $path = __DIR__.'/../../fixtures/files/'.$filename;
-
-        /** @var UploadedFileInterface|\PHPUnit_Framework_MockObject_MockObject $file */
-        $file = $this->createMock(UploadedFileInterface::class);
-        $file->expects($this->once())->method('getStream')->willReturn(stream_for(fopen($path, 'r')));
-        $file->expects($this->once())->method('getClientFilename')->willReturn($filename);
-
-        return $file;
     }
 }


### PR DESCRIPTION
Afin d'éviter la duplication de code lors de l'envoi de fichier via du multipart ainsi que lors du mock des fichiers pour les tests, 2 nouvelles class ont été créées.

A savoir :
- `\Wizaplace\SDK\File\FileService` qui reprend la création de fichiers et la conversion de tableaux en tableau multipart compatible
- `\Wizaplace\SDK\Tests\File\FileTestService` qui permet le mock des fichiers pour les tests du SDK