### PR TITLE
WIZ-87 New optional parameter to allow to add addresses when register

### DIFF
--- a/tests/User/UserServiceTest.php
+++ b/tests/User/UserServiceTest.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace Wizaplace\SDK\Tests\User;
 
 use GuzzleHttp\Psr7\Uri;
+use InvalidArgumentException;
 use Wizaplace\SDK\Authentication\ApiKey;
 use Wizaplace\SDK\Authentication\AuthenticationRequired;
 use Wizaplace\SDK\Authentication\BadCredentials;
@@ -75,6 +76,143 @@ final class UserServiceTest extends ApiTestCase
         $this->assertSame('', $user->getBillingAddress()->getZipCode());
         $this->assertSame('', $user->getBillingAddress()->getCity());
         $this->assertSame('FR', $user->getBillingAddress()->getCountry());
+    }
+
+    public function testCreateUserWithAddresses()
+    {
+        $userEmail = 'user@example.com';
+        $userPassword = 'password';
+        $userFistname = 'John';
+        $userLastname = 'Doe';
+        $userAddresses = [
+            'billing'  => [
+                'title'     => UserTitle::MR(),
+                'firstname' => $userFistname,
+                'lastname'  => $userLastname,
+                'company'   => "Company_b",
+                'phone'     => "Phone_b",
+                'address'   => "Address_b",
+                'address_2' => "Address 2_b",
+                'zipcode'   => "Zipcode_b",
+                'city'      => "City_b",
+                'country'   => "FR",
+            ],
+            'shipping' => [
+                'title'     => UserTitle::MR(),
+                'firstname' => $userFistname,
+                'lastname'  => $userLastname,
+                'company'   => "Company_s",
+                'phone'     => "Phone_s",
+                'address'   => "Address_s",
+                'address_2' => "Address 2_s",
+                'zipcode'   => "Zipcode_s",
+                'city'      => "City_s",
+                'country'   => "FR",
+            ],
+        ];
+
+        $client = $this->buildApiClient();
+        $userService = new UserService($client);
+
+        // create new user
+        $userId = $userService->register($userEmail, $userPassword, $userFistname, $userLastname, $userAddresses);
+
+        // authenticate with newly created user
+        $client->authenticate($userEmail, $userPassword);
+
+        // fetch user
+        $user = $userService->getProfileFromId($userId);
+
+        $this->assertNotNull($user, 'User exists');
+        $this->assertSame($userEmail, $user->getEmail());
+        $this->assertSame($userId, $user->getId());
+        $this->assertSame(null, $user->getTitle());
+        $this->assertSame($userFistname, $user->getFirstname());
+        $this->assertSame($userLastname, $user->getLastname());
+        $this->assertSame(null, $user->getBirthday());
+        $this->assertNull($user->getCompanyId());
+        $this->assertFalse($user->isVendor());
+
+        // shipping address
+        $this->assertNull($user->getShippingAddress()->getTitle());
+        $this->assertSame($userFistname, $user->getShippingAddress()->getFirstName());
+        $this->assertSame($userLastname, $user->getShippingAddress()->getLastName());
+        $this->assertSame($userAddresses['shipping']['company'], $user->getShippingAddress()->getCompany());
+        $this->assertSame($userAddresses['shipping']['phone'], $user->getShippingAddress()->getPhone());
+        $this->assertSame($userAddresses['shipping']['address'], $user->getShippingAddress()->getAddress());
+        $this->assertSame($userAddresses['shipping']['address_2'], $user->getShippingAddress()->getAddressSecondLine());
+        $this->assertSame($userAddresses['shipping']['zipcode'], $user->getShippingAddress()->getZipCode());
+        $this->assertSame($userAddresses['shipping']['city'], $user->getShippingAddress()->getCity());
+        $this->assertSame('FR', $user->getShippingAddress()->getCountry());
+
+        // billing address
+        $this->assertNull($user->getBillingAddress()->getTitle());
+        $this->assertSame($userFistname, $user->getBillingAddress()->getFirstName());
+        $this->assertSame($userLastname, $user->getBillingAddress()->getLastName());
+        $this->assertSame($userAddresses['billing']['company'], $user->getBillingAddress()->getCompany());
+        $this->assertSame($userAddresses['billing']['phone'], $user->getBillingAddress()->getPhone());
+        $this->assertSame($userAddresses['billing']['address'], $user->getBillingAddress()->getAddress());
+        $this->assertSame($userAddresses['billing']['address_2'], $user->getBillingAddress()->getAddressSecondLine());
+        $this->assertSame($userAddresses['billing']['zipcode'], $user->getBillingAddress()->getZipCode());
+        $this->assertSame($userAddresses['billing']['city'], $user->getBillingAddress()->getCity());
+        $this->assertSame('FR', $user->getBillingAddress()->getCountry());
+    }
+
+    public function testCreateUserWithAddressesWithMissingData()
+    {
+        $userEmail = 'user@example.com';
+        $userPassword = 'password';
+        $userFistname = 'John';
+        $userLastname = 'Doe';
+        $userAddresses = [
+            'shipping' => [
+                'title'     => UserTitle::MR(),
+                'firstname' => $userFistname,
+                'lastname'  => $userLastname,
+                'company'   => "Company_s",
+                'phone'     => "Phone_s",
+                'address'   => "Address_s",
+                'address_2' => "Address 2_s",
+                'zipcode'   => "Zipcode_s",
+                'city'      => "City_s",
+                'country'   => "FR",
+            ],
+        ];
+
+        $client = $this->buildApiClient();
+        $userService = new UserService($client);
+
+        // create new user
+        $this->expectException(InvalidArgumentException::class);
+        $userService->register($userEmail, $userPassword, $userFistname, $userLastname, $userAddresses);
+
+
+        $userAddresses = [
+            'billing'  => [
+                'title'     => UserTitle::MR(),
+                'firstname' => $userFistname,
+                'lastname'  => $userLastname,
+            ],
+            'shipping' => [
+                'title'     => UserTitle::MR(),
+                'firstname' => $userFistname,
+                'lastname'  => $userLastname,
+                'company'   => "Company_s",
+                'phone'     => "Phone_s",
+                'address'   => "Address_s",
+                'address_2' => "Address 2_s",
+                'zipcode'   => "Zipcode_s",
+                'city'      => "City_s",
+                'country'   => "FR",
+            ],
+        ];
+
+        $client = $this->buildApiClient();
+        $userService = new UserService($client);
+
+        // create new user
+        $this->expectException(InvalidArgumentException::class);
+        $userService->register($userEmail, $userPassword, $userFistname, $userLastname, $userAddresses);
     }
 
     public function testCreateUserWithFullInfos()

--- a/tests/User/UserServiceTest/testCreateUserWithAddresses.yml
+++ b/tests/User/UserServiceTest/testCreateUserWithAddresses.yml
@@ -1,0 +1,82 @@
+
+-
+    request:
+        method: POST
+        url: 'http://wizaplace.loc/api/v1/users'
+        headers:
+            Host: wizaplace.loc
+            Expect: null
+            Accept-Encoding: null
+            Content-Type: application/x-www-form-urlencoded
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/wiz-87-add-shipping-billings-addresses@42bcc9f
+            VCR-index: '0'
+            Accept: null
+        body: 'email=user%40example.com&password=password&firstName=John&lastName=Doe&billing%5Bfirstname%5D=John&billing%5Blastname%5D=Doe&billing%5Bcompany%5D=Company_b&billing%5Bphone%5D=Phone_b&billing%5Baddress%5D=Address_b&billing%5Baddress_2%5D=Address+2_b&billing%5Bzipcode%5D=Zipcode_b&billing%5Bcity%5D=City_b&billing%5Bcountry%5D=FR&shipping%5Bfirstname%5D=John&shipping%5Blastname%5D=Doe&shipping%5Bcompany%5D=Company_s&shipping%5Bphone%5D=Phone_s&shipping%5Baddress%5D=Address_s&shipping%5Baddress_2%5D=Address+2_s&shipping%5Bzipcode%5D=Zipcode_s&shipping%5Bcity%5D=City_s&shipping%5Bcountry%5D=FR'
+    response:
+        status:
+            http_version: '1.1'
+            code: '201'
+            message: Created
+        headers:
+            Date: 'Thu, 04 Oct 2018 13:08:32 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'max-age=0, must-revalidate, private'
+            Content-Language: fr
+            X-Debug-Token: 9e3b56
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/9e3b56'
+            Set-Cookie: 'sf_redirect=%7B%22token%22%3A%229e3b56%22%2C%22route%22%3A%22api_user_register%22%2C%22method%22%3A%22POST%22%2C%22controller%22%3A%22marketplace.user.api.usercontroller%3AregisterAction%22%2C%22status_code%22%3A201%2C%22status_text%22%3A%22Created%22%7D; path=/; httponly'
+            Content-Length: '9'
+            Content-Type: application/json
+        body: '{"id":13}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/users/authenticate'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            Authorization: 'Basic dXNlckBleGFtcGxlLmNvbTpwYXNzd29yZA=='
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/wiz-87-add-shipping-billings-addresses@42bcc9f
+            VCR-index: '1'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Thu, 04 Oct 2018 13:08:33 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 8d3a95
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/8d3a95'
+            Content-Length: '63'
+            Content-Type: application/json
+        body: '{"id":13,"apiKey":"yn1699ecZqOtQ\/NEnN7CSPeZWfup8\/6L0if6huzh"}'
+-
+    request:
+        method: GET
+        url: 'http://wizaplace.loc/api/v1/users/13'
+        headers:
+            Host: wizaplace.loc
+            Accept-Encoding: null
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/wiz-87-add-shipping-billings-addresses@42bcc9f
+            Authorization: 'token yn1699ecZqOtQ/NEnN7CSPeZWfup8/6L0if6huzh'
+            VCR-index: '2'
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Date: 'Thu, 04 Oct 2018 13:08:33 GMT'
+            Server: 'Apache/2.4.25 (Debian)'
+            Cache-Control: 'no-cache, private'
+            Content-Language: fr
+            X-Debug-Token: 6d6d96
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/6d6d96'
+            Content-Length: '665'
+            Content-Type: application/json
+        body: '{"id":13,"title":null,"email":"user@example.com","type":"C","companyId":null,"firstName":"John","lastName":"Doe","birthday":null,"loyaltyIdentifier":null,"addresses":{"billing":{"title":"","firstname":"John","lastname":"Doe","company":"Company_b","phone":"Phone_b","address":"Address_b","address_2":"Address 2_b","zipcode":"Zipcode_b","city":"City_b","country":"FR","37":3,"38":3,"40":"Company_b","39":"Company_b"},"shipping":{"title":"","firstname":"John","lastname":"Doe","company":"Company_s","phone":"Phone_s","address":"Address_s","address_2":"Address 2_s","zipcode":"Zipcode_s","city":"City_s","country":"FR","37":3,"38":3,"40":"Company_s","39":"Company_s"}}}'


### PR DESCRIPTION
Ajout d'un nouveau paramètre optionnel `$addresses` à la méthode `UserService::register`. C'est un tableau contenant les informations des adresses de facturation et de livraison.

```
$addresses = [
            'billing'  => [
                'title'     => UserTitle::MR(),
                'firstname' => $userFistname,
                'lastname'  => $userLastname,
                'company'   => "Company_b",
                'phone'     => "Phone_b",
                'address'   => "Address_b",
                'address_2' => "Address 2_b",
                'zipcode'   => "Zipcode_b",
                'city'      => "City_b",
                'country'   => "FR",
            ],
            'shipping' => [
                'title'     => UserTitle::MR(),
                'firstname' => $userFistname,
                'lastname'  => $userLastname,
                'company'   => "Company_s",
                'phone'     => "Phone_s",
                'address'   => "Address_s",
                'address_2' => "Address 2_s",
                'zipcode'   => "Zipcode_s",
                'city'      => "City_s",
                'country'   => "FR",
            ],
        ]
```