### PR TITLE
WIZ-149 fix autoloader

### DIFF
--- a/src/Pim/Product/UpdateShippingCommand.php
+++ b/src/Pim/Product/UpdateShippingCommand.php
@@ -181,9 +181,13 @@ final class UpdateShippingCommand implements ArrayableInterface
      */
     public function validate(): void
     {
-        /** @var ClassLoader $loader */
-        $loader = require __DIR__.'/../../../vendor/autoload.php';
-        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+        $autoload = __DIR__.'/../../../vendor/autoload.php';
+        // Le fichier n'est disponible que pour les tests en local
+        if (file_exists($autoload)) {
+            /** @var ClassLoader $loader */
+            $loader = require $autoload;
+            AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+        }
 
         $builder = Validation::createValidatorBuilder()
             ->enableAnnotationMapping();

--- a/src/Pim/Product/UpdateShippingCommand.php
+++ b/src/Pim/Product/UpdateShippingCommand.php
@@ -7,8 +7,6 @@ declare(strict_types = 1);
 
 namespace Wizaplace\SDK\Pim\Product;
 
-use Composer\Autoload\ClassLoader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validation;
@@ -181,14 +179,6 @@ final class UpdateShippingCommand implements ArrayableInterface
      */
     public function validate(): void
     {
-        $autoload = __DIR__.'/../../../vendor/autoload.php';
-        // Le fichier n'est disponible que pour les tests en local
-        if (file_exists($autoload)) {
-            /** @var ClassLoader $loader */
-            $loader = require $autoload;
-            AnnotationRegistry::registerLoader([$loader, 'loadClass']);
-        }
-
         $builder = Validation::createValidatorBuilder()
             ->enableAnnotationMapping();
 

--- a/tests/Pim/Product/ProductServiceTest.php
+++ b/tests/Pim/Product/ProductServiceTest.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace Wizaplace\SDK\Tests\Pim\Product;
 
+use Composer\Autoload\ClassLoader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
 use Wizaplace\SDK\Exception\NotFound;
@@ -818,6 +820,8 @@ final class ProductServiceTest extends ApiTestCase
 
     public function testPutProductShipping()
     {
+        $this->loadAnnotations();
+
         $command = new UpdateShippingCommand();
         $command->setStatus("D")
                 ->setRates([
@@ -845,6 +849,8 @@ final class ProductServiceTest extends ApiTestCase
 
     public function testUpdateShippingCommandConstraints()
     {
+        $this->loadAnnotations();
+
         $command = new UpdateShippingCommand();
         $command->setStatus("Status qui n'existe pas")
             ->setRates([
@@ -872,5 +878,12 @@ final class ProductServiceTest extends ApiTestCase
         $apiClient->authenticate($userEmail, $userPassword);
 
         return new ProductService($apiClient);
+    }
+
+    private function loadAnnotations() : void
+    {
+        /** @var ClassLoader $loader */
+        $loader = require __DIR__.'/../../../vendor/autoload.php';
+        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
     }
 }


### PR DESCRIPTION
Le fichier `autoload.php` est manquant quand le SDK est installé via un projet global. Il n'est présent que lorsqu'un `composer install` est lancé directement dans le SDK