### PR TITLE
Update type hint parameters shipping/billing of userService::register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release 
 
 - Added `\Wizaplace\SDK\Order\OrderItem::getProductImageId`
+- Updated type hint optional parameters `$billing` and `$shipping` `\Wizaplace\SDK\User\UserService::register`
 
 ## 1.40.0
 

--- a/src/User/UserService.php
+++ b/src/User/UserService.php
@@ -95,8 +95,8 @@ final class UserService extends AbstractService
      * @param string           $firstName
      * @param string           $lastName
      *
-     * @param UserAddress|null $billing
-     * @param UserAddress|null $shipping
+     * @param UpdateUserAddressCommand|null $billing
+     * @param UpdateUserAddressCommand|null $shipping
      *
      * @return int ID of the created user.
      *
@@ -108,8 +108,8 @@ final class UserService extends AbstractService
         string $password,
         string $firstName = '',
         string $lastName = '',
-        UserAddress $billing = null,
-        UserAddress $shipping = null
+        UpdateUserAddressCommand $billing = null,
+        UpdateUserAddressCommand $shipping = null
     ): int {
         try {
             $data = [
@@ -119,10 +119,10 @@ final class UserService extends AbstractService
                 'lastName'  => $lastName,
             ];
 
-            if ($billing instanceof UserAddress && $shipping instanceof UserAddress) {
-                $data['billing']  = $billing->toArray();
-                $data['shipping'] = $shipping->toArray();
-            } elseif ($billing instanceof UserAddress xor $shipping instanceof UserAddress) {
+            if ($billing instanceof UpdateUserAddressCommand && $shipping instanceof UpdateUserAddressCommand) {
+                $data['billing']  = self::serializeUserAddressUpdate($billing);
+                $data['shipping'] = self::serializeUserAddressUpdate($shipping);
+            } elseif ($billing instanceof UpdateUserAddressCommand xor $shipping instanceof UpdateUserAddressCommand) {
                 throw new \Exception("Both addresses are required if you set an address.");
             }
 

--- a/tests/User/UserServiceTest.php
+++ b/tests/User/UserServiceTest.php
@@ -84,30 +84,29 @@ final class UserServiceTest extends ApiTestCase
         $userPassword = 'password';
         $userFistname = 'John';
         $userLastname = 'Doe';
-        $userBilling = new UserAddress([
-            'title'     => UserTitle::MR()->getValue(),
-            'firstname' => $userFistname,
-            'lastname'  => $userLastname,
-            'company'   => "Company_b",
-            'phone'     => "Phone_b",
-            'address'   => "Address_b",
-            'address_2' => "Address 2_b",
-            'zipcode'   => "Zipcode_b",
-            'city'      => "City_b",
-            'country'   => "FR",
-        ]);
-        $userShipping = new UserAddress([
-            'title'     => UserTitle::MR()->getValue(),
-            'firstname' => $userFistname,
-            'lastname'  => $userLastname,
-            'company'   => "Company_s",
-            'phone'     => "Phone_s",
-            'address'   => "Address_s",
-            'address_2' => "Address 2_s",
-            'zipcode'   => "Zipcode_s",
-            'city'      => "City_s",
-            'country'   => "FR",
-        ]);
+        $userBilling = new UpdateUserAddressCommand();
+        $userBilling->setTitle(UserTitle::MR());
+        $userBilling->setFirstName($userFistname);
+        $userBilling->setLastName($userLastname);
+        $userBilling->setPhone('Phone_b');
+        $userBilling->setAddress('Address_b');
+        $userBilling->setAddressSecondLine('Address 2_b');
+        $userBilling->setCompany('Company_b');
+        $userBilling->setZipCode('Zipcode_b');
+        $userBilling->setCity('City_b');
+        $userBilling->setCountry('FR');
+
+        $userShipping = new UpdateUserAddressCommand();
+        $userShipping->setTitle(UserTitle::MR());
+        $userShipping->setFirstName($userFistname);
+        $userShipping->setLastName($userLastname);
+        $userShipping->setPhone('Phone_s');
+        $userShipping->setAddress('Address_s');
+        $userShipping->setAddressSecondLine('Address 2_s');
+        $userShipping->setCompany('Company_s');
+        $userShipping->setZipCode('Zipcode_s');
+        $userShipping->setCity('City_s');
+        $userShipping->setCountry('FR');
 
         $client = $this->buildApiClient();
         $userService = new UserService($client);
@@ -162,30 +161,29 @@ final class UserServiceTest extends ApiTestCase
         $userPassword = 'password';
         $userFistname = 'John';
         $userLastname = 'Doe';
-        $userBilling = new UserAddress([
-            'title'     => UserTitle::MR()->getValue(),
-            'firstname' => $userFistname,
-            'lastname'  => $userLastname,
-            'company'   => "Company_b",
-            'phone'     => "Phone_b",
-            'address'   => "Address_b",
-            'address_2' => "Address 2_b",
-            'zipcode'   => "Zipcode_b",
-            'city'      => "City_b",
-            'country'   => "FR",
-        ]);
-        $userShipping = new UserAddress([
-            'title'     => UserTitle::MR()->getValue(),
-            'firstname' => $userFistname,
-            'lastname'  => $userLastname,
-            'company'   => "Company_s",
-            'phone'     => "Phone_s",
-            'address'   => "Address_s",
-            'address_2' => "Address 2_s",
-            'zipcode'   => "Zipcode_s",
-            'city'      => "City_s",
-            'country'   => "FR",
-        ]);
+        $userBilling = new UpdateUserAddressCommand();
+        $userBilling->setTitle(UserTitle::MR());
+        $userBilling->setFirstName($userFistname);
+        $userBilling->setLastName($userLastname);
+        $userBilling->setPhone('Phone_b');
+        $userBilling->setAddress('Address_b');
+        $userBilling->setAddressSecondLine('Address 2_b');
+        $userBilling->setCompany('Company_b');
+        $userBilling->setZipCode('Zipcode_b');
+        $userBilling->setCity('City_b');
+        $userBilling->setCountry('FR');
+
+        $userShipping = new UpdateUserAddressCommand();
+        $userShipping->setTitle(UserTitle::MR());
+        $userShipping->setFirstName($userFistname);
+        $userShipping->setLastName($userLastname);
+        $userShipping->setPhone('Phone_s');
+        $userShipping->setAddress('Address_s');
+        $userShipping->setAddressSecondLine('Address 2_s');
+        $userShipping->setCompany('Company_s');
+        $userShipping->setZipCode('Zipcode_s');
+        $userShipping->setCity('City_s');
+        $userShipping->setCountry('FR');
 
         $client = $this->buildApiClient();
         $userService = new UserService($client);
@@ -205,30 +203,29 @@ final class UserServiceTest extends ApiTestCase
         $userPassword = 'password';
         $userFistname = 'Paul';
         $userLastname = 'Jean';
-        $userBilling = new UserAddress([
-            'title'     => UserTitle::MR()->getValue(),
-            'firstname' => $userFistname,
-            'lastname'  => $userLastname,
-            'company'   => "Company_b",
-            'phone'     => "",
-            'address'   => "",
-            'address_2' => "",
-            'zipcode'   => "",
-            'city'      => "",
-            'country'   => "",
-        ]);
-        $userShipping = new UserAddress([
-            'title'     => UserTitle::MR()->getValue(),
-            'firstname' => $userFistname,
-            'lastname'  => $userLastname,
-            'company'   => "Company_s",
-            'phone'     => "",
-            'address'   => "",
-            'address_2' => "",
-            'zipcode'   => "",
-            'city'      => "",
-            'country'   => "",
-        ]);
+        $userBilling = new UpdateUserAddressCommand();
+        $userBilling->setTitle(UserTitle::MR());
+        $userBilling->setFirstName($userFistname);
+        $userBilling->setLastName($userLastname);
+        $userBilling->setPhone("");
+        $userBilling->setAddress("");
+        $userBilling->setAddressSecondLine("");
+        $userBilling->setCompany('Company_b');
+        $userBilling->setZipCode("");
+        $userBilling->setCity("");
+        $userBilling->setCountry("");
+
+        $userShipping = new UpdateUserAddressCommand();
+        $userShipping->setTitle(UserTitle::MR());
+        $userShipping->setFirstName($userFistname);
+        $userShipping->setLastName($userLastname);
+        $userShipping->setPhone("");
+        $userShipping->setAddress("");
+        $userShipping->setAddressSecondLine("");
+        $userShipping->setCompany('Company_s');
+        $userShipping->setZipCode("");
+        $userShipping->setCity("");
+        $userShipping->setCountry("");
 
         $client = $this->buildApiClient();
         $userService = new UserService($client);


### PR DESCRIPTION
`UserAddress` constructor is internal so it should not be used as a parameter of a public method.

## Checklist

- [x] Changelog updated
