### PR TITLE
WIZ-252 add Wizaplace\SDK\Pim\Product\ProductSummary::getShippings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `\Wizaplace\SDK\Order\OrderItem::getProductImageId`
 - Updated `\Wizaplace\SDK\Organisation\OrganisationService::getOrganisationOrders`
 - Updated `tests/Organisation/OrganisationServiceTest`
+- Added `Wizaplace\SDK\Pim\Product\ProductSummary::getShippings`
 
 ## 1.40.0
 

--- a/src/Pim/Product/ProductSummary.php
+++ b/src/Pim/Product/ProductSummary.php
@@ -70,6 +70,9 @@ class ProductSummary
     /** @var ProductAttachment[] */
     private $attachments;
 
+    /** @var Shipping[] */
+    private $shippings;
+
     /**
      * @internal
      */
@@ -100,6 +103,9 @@ class ProductSummary
         $this->attachments = array_map(static function (array $attachmentData): ProductAttachment {
             return new ProductAttachment($attachmentData);
         }, $data['attachments'] ?? []);
+        $this->shippings = array_map(function ($shipping) {
+            return new Shipping($shipping);
+        }, $data['shippings'] ?? []);
     }
 
     public function getId(): int
@@ -201,5 +207,13 @@ class ProductSummary
     public function getAttachments(): array
     {
         return $this->attachments;
+    }
+
+    /**
+     * @return Shipping[]
+     */
+    public function getShippings(): array
+    {
+        return $this->shippings;
     }
 }

--- a/tests/Pim/Product/ProductServiceTest.php
+++ b/tests/Pim/Product/ProductServiceTest.php
@@ -96,6 +96,9 @@ final class ProductServiceTest extends ApiTestCase
         $this->assertNull($declination->getCrossedOutPrice());
         $this->assertNull($declination->getCode());
         $this->assertNull($declination->getAffiliateLink());
+        foreach ($product->getShippings() as $shipping) {
+            $this->assertInstanceOf(Shipping::class, $shipping);
+        }
     }
 
     public function testGetProductWithOptionsById()

--- a/tests/Pim/Product/ProductServiceTest/testGetProductById.yml
+++ b/tests/Pim/Product/ProductServiceTest/testGetProductById.yml
@@ -7,7 +7,7 @@
             Host: wizaplace.loc
             Accept-Encoding: null
             Authorization: 'Basic YWRtaW5Ad2l6YXBsYWNlLmNvbTpwYXNzd29yZA=='
-            User-Agent: Wizaplace-PHP-SDK/dev-feat-infinitestock@f75cf31
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/wiz-252-add-shippings-data@21733aa
             VCR-index: '0'
             Accept: null
     response:
@@ -16,15 +16,15 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Fri, 12 Oct 2018 14:28:56 GMT'
+            Date: 'Mon, 12 Nov 2018 11:39:04 GMT'
             Server: 'Apache/2.4.25 (Debian)'
             Cache-Control: 'no-cache, private'
             Content-Language: fr
-            X-Debug-Token: 95909d
-            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/95909d'
-            Content-Length: '61'
+            X-Debug-Token: c2e3f0
+            X-Debug-Token-Link: 'http://wizaplace.loc/_profiler/c2e3f0'
+            Content-Length: '60'
             Content-Type: application/json
-        body: '{"id":2,"apiKey":"m461H0gCQQzPnB4MI8Ojtv5dsGK82Z1v8+5yU73\/"}'
+        body: '{"id":2,"apiKey":"VSoWcOzcVMWJnMKkn3DuhQELccwJ2wybAOR+wU3F"}'
 -
     request:
         method: GET
@@ -32,8 +32,8 @@
         headers:
             Host: wizaplace.loc
             Accept-Encoding: null
-            User-Agent: Wizaplace-PHP-SDK/dev-feat-infinitestock@f75cf31
-            Authorization: 'token m461H0gCQQzPnB4MI8Ojtv5dsGK82Z1v8+5yU73/'
+            User-Agent: Wizaplace-PHP-SDK/dev-feature/wiz-252-add-shippings-data@21733aa
+            Authorization: 'token VSoWcOzcVMWJnMKkn3DuhQELccwJ2wybAOR+wU3F'
             VCR-index: '1'
             Accept: null
     response:
@@ -42,12 +42,12 @@
             code: '200'
             message: OK
         headers:
-            Date: 'Fri, 12 Oct 2018 14:28:56 GMT'
+            Date: 'Mon, 12 Nov 2018 11:39:04 GMT'
             Server: 'Apache/2.4.25 (Debian)'
             Cache-Control: 'no-cache, private'
             Content-Language: fr
-            X-Debug-Token: 98fa1c
-            X-Debug-Token-Link: 'https://wizaplace.loc/_profiler/98fa1c'
-            Content-Length: '1132'
+            X-Debug-Token: aa2b06
+            X-Debug-Token-Link: 'https://wizaplace.loc/_profiler/aa2b06'
+            Content-Length: '2084'
             Content-Type: application/json
-        body: '{"product_id":8,"product_code":"32094574920","status":"A","company_id":3,"approved":"Y","weight":1.23,"timestamp":1539354521,"updated_timestamp":1539354521,"is_edp":"N","unlimited_download":"N","free_shipping":"N","avail_since":1386316800,"tax_ids":[2],"crossed_out_price":0.0,"affiliate_link":"","product_template_type":"product","infinite_stock":false,"product":"Product with complex attributes","short_description":"","full_description":"","category_ids":[6],"main_category":6,"main_pair":[],"image_pairs":[],"video":null,"attachments":[],"inventory":[{"combination":[],"amount":15,"price":15.0}],"green_tax":0.0,"supplier_ref":"TEST-ATTRIBUTES","condition":"N","free_features":{"Free attribute multiple":["r\u00e9ponse - 1 #","r\u00e9ponse - 2 @",4985],"Free attribute simple":["valeur simple du free attribute #12M%M_\u00b009\u00a3*\/.?"],"Free attribute simple mais en tableau":["une bien belle valeur d\u00e9j\u00e0 encapsul\u00e9e"],"Free attribute integer ?":[92254094],"Free attribute integer mais en tableau":["la m\u00eame histoire par ici"]},"geolocation":{"latitude":null,"longitude":null,"label":null,"zipcode":null}}'
+        body: '{"product_id":8,"product_code":"32094574920","status":"A","company_id":3,"approved":"Y","weight":1.23,"timestamp":1542022722,"updated_timestamp":1542022723,"is_edp":"N","unlimited_download":"N","free_shipping":"N","avail_since":1386316800,"tax_ids":[2],"crossed_out_price":0.0,"affiliate_link":"","product_template_type":"product","infinite_stock":false,"product":"Product with complex attributes","short_description":"","full_description":"","category_ids":[6],"main_category":6,"main_pair":[],"image_pairs":[],"video":null,"attachments":[],"inventory":[{"combination":[],"amount":15,"price":15.0}],"green_tax":0.0,"supplier_ref":"TEST-ATTRIBUTES","condition":"N","free_features":{"Free attribute multiple":["r\u00e9ponse - 1 #","r\u00e9ponse - 2 @",4985],"Free attribute simple":["valeur simple du free attribute #12M%M_\u00b009\u00a3*\/.?"],"Free attribute simple mais en tableau":["une bien belle valeur d\u00e9j\u00e0 encapsul\u00e9e"],"Free attribute integer ?":[92254094],"Free attribute integer mais en tableau":["la m\u00eame histoire par ici"]},"geolocation":{"latitude":null,"longitude":null,"label":null,"zipcode":null},"shippings":{"1":{"shipping_id":1,"status":"A","shipping":"TNT Express","delivery_time":"24h","rates":[{"amount":0,"value":null},{"amount":1,"value":null}],"specific_rate":false,"product_id":8,"description":"<p>Code : TNT01<\/p>\r\n<p>Type : Livraison &agrave; domicile <br \/> Mode : EXP<\/p>\r\n<p>Tel : 08 25 03 30 33<\/p>\r\n<p>Email :<\/p>\r\n<p>Adresse : 58 Avenue Leclerc <br \/> 69007Lyon<br \/>France<\/p>\r\n<p>URL tracking : http:\/\/www.tnt.fr\/suivi<\/p>\r\n<p>Service : Transport express au domicile, au travail ou en relais colis.<\/p>"},"38":{"shipping_id":38,"status":"A","shipping":"Lettre prioritaire","delivery_time":"","rates":[{"amount":0,"value":0.0},{"amount":1,"value":0.0}],"specific_rate":false,"product_id":8,"description":null},"39":{"shipping_id":39,"status":"A","shipping":"Colissmo","delivery_time":"","rates":[{"amount":0,"value":0.0},{"amount":1,"value":0.0}],"specific_rate":false,"product_id":8,"description":null}}}'


### PR DESCRIPTION
[#WIZ-252](https://wizaplace.atlassian.net/browse/WIZ-252)

Actuellement, quand les datas retournées par `/api/v1/products/[id]` correspondent à une FPU, les shippings retournés avec ne peuvent pas être rattachés à un product en particulier.