### PR TITLE
Fix error with undefined index

### DIFF
--- a/src/Catalog/Facet/NumericFacet.php
+++ b/src/Catalog/Facet/NumericFacet.php
@@ -28,8 +28,8 @@ final class NumericFacet extends Facet
     public function __construct(array $data)
     {
         parent::__construct($data);
-        $this->min = $data['values']['min'];
-        $this->max = $data['values']['max'];
+        $this->min = $data['values']['min'] ?? 0;
+        $this->max = $data['values']['max'] ?? PHP_INT_MAX;
     }
 
     public function getMin(): float


### PR DESCRIPTION
## Checklist

- [x] Changelog updated

Fix a very strange error from the SDK:

```json
{
  "errors": [
    {
      "debugMessage": "Notice: Undefined index: min",
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      },
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "vehicleOffers"
      ],
      "trace": [
        {
          "file": "/srv/api/vendor/wizaplace/sdk/src/Catalog/Facet/Facet.php",
          "line": 44,
          "call": "Wizaplace\\SDK\\Catalog\\Facet\\NumericFacet::__construct(array(4))"
        },
        {
          "file": "/srv/api/vendor/wizaplace/sdk/src/Catalog/SearchResult.php",
          "line": 44,
          "call": "Wizaplace\\SDK\\Catalog\\Facet\\Facet::buildFromJson(array(4))"
        },
        {
          "call": "Wizaplace\\SDK\\Catalog\\SearchResult::Wizaplace\\SDK\\Catalog\\{closure}(array(4))"
        },
        {
          "file": "/srv/api/vendor/wizaplace/sdk/src/Catalog/SearchResult.php",
          "line": 46,
          "function": "array_map(instance of Closure, array(1))"
        },
        {
          "file": "/srv/api/vendor/wizaplace/sdk/src/Catalog/CatalogService.php",
          "line": 284,
          "call": "Wizaplace\\SDK\\Catalog\\SearchResult::__construct(array(3))"
        },
        {
          "file": "/srv/api/src/Service/WizaPlace/WizaPlaceCatalogClient.php",
          "line": 38,
          "call": "Wizaplace\\SDK\\Catalog\\CatalogService::search(array(5), array(1), array(0), 30, 1, null)"
        },
        {
          "file": "/srv/api/src/DataProvider/ProductDataCollectionProvider.php",
          "line": 48,
          "call": "App\\Service\\WizaPlace\\WizaPlaceCatalogClient::getSearchProduct((empty string), array(0), array(1), 1, 30)"
        },
```

Here is the values of facets that are passed:

```
  "facets" => array:1 [
    0 => array:4 [
      "name" => "categories"
      "label" => "Catégorie"
      "values" => array:1 [
        0 => "3"
      ]
      "isNumeric" => true
    ]
  ]
```

These values are passed there:

https://github.com/wizaplace/wizaplace-php-sdk/blob/775bb23dbe9f10097906ebbb9fd90114e931019e/src/Catalog/SearchResult.php#L42-L47