### PR TITLE
feat: add extra field in CompanyListItem

### DIFF
--- a/src/Catalog/CompanyListItem.php
+++ b/src/Catalog/CompanyListItem.php
@@ -55,6 +55,9 @@ final class CompanyListItem
 
     /** @var CompanyAddress */
     private $fullAddress;
+    
+    /** @var array */
+    private $extra = [];
 
     /**
      * @internal
@@ -79,6 +82,7 @@ final class CompanyListItem
         }
         $this->averageRating = $data['averageRating'];
         $this->fullAddress = new CompanyAddress($data['fullAddress']);
+        $this->extra = (array) $data['extra'];
     }
 
     /**
@@ -173,5 +177,13 @@ final class CompanyListItem
     public function getAverageRating(): ?int
     {
         return $this->averageRating;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExtra(): array
+    {
+        return $this->extra;
     }
 }


### PR DESCRIPTION
__Add extra field in CompanyListItem__

The field is returned by https://sandbox.wizaplace.com/api/v1/doc/#tag/Catalog/paths/~1catalog~1companies/get endpoint but not set in CompanyListItem.

__Test__ : i could not update `testGetCompanies` test case

## Checklist

- [ ] Changelog updated
